### PR TITLE
Pseudonymization via builder pattern

### DIFF
--- a/src/dapla_pseudo/__init__.py
+++ b/src/dapla_pseudo/__init__.py
@@ -22,11 +22,10 @@ import importlib
 __version__ = importlib.metadata.version("dapla_toolbelt_pseudo")
 
 from .v1 import PseudoClient
+from .v1 import PseudoData
 from .v1 import depseudonymize
 from .v1 import pseudonymize
 from .v1 import repseudonymize
-
-from .v1 import PseudoData
 
 
 __all__ = [

--- a/src/dapla_pseudo/__init__.py
+++ b/src/dapla_pseudo/__init__.py
@@ -26,5 +26,13 @@ from .v1 import depseudonymize
 from .v1 import pseudonymize
 from .v1 import repseudonymize
 
+from .v1 import PseudoData
 
-__all__ = ["PseudoClient", "pseudonymize", "depseudonymize", "repseudonymize"]
+
+__all__ = [
+    "PseudoClient",
+    "pseudonymize",
+    "depseudonymize",
+    "repseudonymize",
+    "PseudoData",
+]

--- a/src/dapla_pseudo/constants.py
+++ b/src/dapla_pseudo/constants.py
@@ -1,9 +1,9 @@
-"""This module defines constants that is referenced throughout the codebase."""
+"""This module defines constants that are referenced throughout the codebase."""
 from enum import Enum
 
 
 class Env(str, Enum):
-    """Environment variables."""
+    """Environment variable keys."""
 
     PSEUDO_SERVICE_URL = "PSEUDO_SERVICE_URL"
     PSEUDO_SERVICE_AUTH_TOKEN = "PSEUDO_SERVICE_AUTH_TOKEN"  # noqa S105
@@ -26,7 +26,7 @@ class PredefinedKeys(str, Enum):
 
 
 class PseudoFunctionTypes(str, Enum):
-    """Names of 'global keys' that the Dapla Pseudo Service is familiar with."""
+    """Names of well known pseudo functions."""
 
     DAEAD = "daead"
     MAP_SID = "map-sid"

--- a/src/dapla_pseudo/constants.py
+++ b/src/dapla_pseudo/constants.py
@@ -1,6 +1,5 @@
 """This module defines constants that is referenced throughout the codebase."""
 from enum import Enum
-from typing import Final
 
 
 class Env(str, Enum):
@@ -21,5 +20,6 @@ class PredefinedKeys(str, Enum):
 class PseudoFunctionTypes(str, Enum):
     """Names of 'global keys' that the Dapla Pseudo Service is familiar with."""
 
-    DAEAD: Final[str] = "daead"
-    MAP_SID: Final[str] = "map-sid"
+    DAEAD = "daead"
+    MAP_SID = "map-sid"
+    FF31 = "ff31"

--- a/src/dapla_pseudo/constants.py
+++ b/src/dapla_pseudo/constants.py
@@ -19,5 +19,13 @@ class PredefinedKeys(BaseModel):
     PAPIS_COMMON_KEY_1: Final[str] = "papis-common-key-1"
 
 
+class PseudoFunctionTypes(BaseModel):
+    """Names of 'global keys' that the Dapla Pseudo Service is familiar with."""
+
+    DAEAD: Final[str] = "daead"
+    MAP_SID: Final[str] = "map-sid"
+
+
 env = Env()
 predefined_keys = PredefinedKeys()
+pseudo_function_types = PseudoFunctionTypes()

--- a/src/dapla_pseudo/constants.py
+++ b/src/dapla_pseudo/constants.py
@@ -8,7 +8,7 @@ class Env(str, Enum):
     PSEUDO_SERVICE_URL = "PSEUDO_SERVICE_URL"
     PSEUDO_SERVICE_AUTH_TOKEN = "PSEUDO_SERVICE_AUTH_TOKEN"  # noqa S105
 
-    def __str__(self):
+    def __str__(self) -> str:
         """Use value for string representation."""
         return str(self.value)
 
@@ -20,7 +20,7 @@ class PredefinedKeys(str, Enum):
     SSB_COMMON_KEY_2 = "ssb-common-key-2"
     PAPIS_COMMON_KEY_1 = "papis-common-key-1"
 
-    def __str__(self):
+    def __str__(self) -> str:
         """Use value for string representation."""
         return str(self.value)
 
@@ -32,6 +32,6 @@ class PseudoFunctionTypes(str, Enum):
     MAP_SID = "map-sid"
     FF31 = "ff31"
 
-    def __str__(self):
+    def __str__(self) -> str:
         """Use value for string representation."""
         return str(self.value)

--- a/src/dapla_pseudo/constants.py
+++ b/src/dapla_pseudo/constants.py
@@ -1,31 +1,25 @@
 """This module defines constants that is referenced throughout the codebase."""
+from enum import Enum
 from typing import Final
 
-from pydantic import BaseModel
 
-
-class Env(BaseModel):
+class Env(str, Enum):
     """Environment variables."""
 
-    PSEUDO_SERVICE_URL: Final[str] = "PSEUDO_SERVICE_URL"
-    PSEUDO_SERVICE_AUTH_TOKEN: Final[str] = "PSEUDO_SERVICE_AUTH_TOKEN"
+    PSEUDO_SERVICE_URL = "PSEUDO_SERVICE_URL"
+    PSEUDO_SERVICE_AUTH_TOKEN = "PSEUDO_SERVICE_AUTH_TOKEN"  # noqa S105
 
 
-class PredefinedKeys(BaseModel):
+class PredefinedKeys(str, Enum):
     """Names of 'global keys' that the Dapla Pseudo Service is familiar with."""
 
-    SSB_COMMON_KEY_1: Final[str] = "ssb-common-key-1"
-    SSB_COMMON_KEY_2: Final[str] = "ssb-common-key-2"
-    PAPIS_COMMON_KEY_1: Final[str] = "papis-common-key-1"
+    SSB_COMMON_KEY_1 = "ssb-common-key-1"
+    SSB_COMMON_KEY_2 = "ssb-common-key-2"
+    PAPIS_COMMON_KEY_1 = "papis-common-key-1"
 
 
-class PseudoFunctionTypes(BaseModel):
+class PseudoFunctionTypes(str, Enum):
     """Names of 'global keys' that the Dapla Pseudo Service is familiar with."""
 
     DAEAD: Final[str] = "daead"
     MAP_SID: Final[str] = "map-sid"
-
-
-env = Env()
-predefined_keys = PredefinedKeys()
-pseudo_function_types = PseudoFunctionTypes()

--- a/src/dapla_pseudo/constants.py
+++ b/src/dapla_pseudo/constants.py
@@ -8,6 +8,10 @@ class Env(str, Enum):
     PSEUDO_SERVICE_URL = "PSEUDO_SERVICE_URL"
     PSEUDO_SERVICE_AUTH_TOKEN = "PSEUDO_SERVICE_AUTH_TOKEN"  # noqa S105
 
+    def __str__(self):
+        """Use value for string representation."""
+        return str(self.value)
+
 
 class PredefinedKeys(str, Enum):
     """Names of 'global keys' that the Dapla Pseudo Service is familiar with."""
@@ -16,6 +20,10 @@ class PredefinedKeys(str, Enum):
     SSB_COMMON_KEY_2 = "ssb-common-key-2"
     PAPIS_COMMON_KEY_1 = "papis-common-key-1"
 
+    def __str__(self):
+        """Use value for string representation."""
+        return str(self.value)
+
 
 class PseudoFunctionTypes(str, Enum):
     """Names of 'global keys' that the Dapla Pseudo Service is familiar with."""
@@ -23,3 +31,7 @@ class PseudoFunctionTypes(str, Enum):
     DAEAD = "daead"
     MAP_SID = "map-sid"
     FF31 = "ff31"
+
+    def __str__(self):
+        """Use value for string representation."""
+        return str(self.value)

--- a/src/dapla_pseudo/v1/__init__.py
+++ b/src/dapla_pseudo/v1/__init__.py
@@ -5,5 +5,13 @@ from dapla_pseudo.v1.ops import depseudonymize
 from dapla_pseudo.v1.ops import pseudonymize
 from dapla_pseudo.v1.ops import repseudonymize
 
+from dapla_pseudo.v1.builder import PseudoData
 
-__all__ = ["PseudoClient", "pseudonymize", "depseudonymize", "repseudonymize"]
+
+__all__ = [
+    "PseudoClient",
+    "pseudonymize",
+    "depseudonymize",
+    "repseudonymize",
+    "PseudoData",
+]

--- a/src/dapla_pseudo/v1/__init__.py
+++ b/src/dapla_pseudo/v1/__init__.py
@@ -1,11 +1,10 @@
 """Pseudo Service version 1 implementation."""
 
+from dapla_pseudo.v1.builder import PseudoData
 from dapla_pseudo.v1.client import PseudoClient
 from dapla_pseudo.v1.ops import depseudonymize
 from dapla_pseudo.v1.ops import pseudonymize
 from dapla_pseudo.v1.ops import repseudonymize
-
-from dapla_pseudo.v1.builder import PseudoData
 
 
 __all__ = [

--- a/src/dapla_pseudo/v1/builder.py
+++ b/src/dapla_pseudo/v1/builder.py
@@ -50,13 +50,11 @@ class PseudoData:
             self._dataframe = dataframe
 
         def on_field(self, field: str) -> "PseudoData._PseudoFunctionSelector":
-            """Specify the field to be pseudonymized"""
-            # Extract/specify field
+            """Specify a single field to be pseudonymized."""
             return PseudoData._PseudoFunctionSelector(self._dataframe, [Field(pattern=f"**/{field}")])
 
         def on_fields(self, *fields: str) -> "PseudoData._PseudoFunctionSelector":
-            """Specify the field to be pseudonymized"""
-            # Extract/specify field
+            """Specify multiple fields to be pseudonymized."""
             return PseudoData._PseudoFunctionSelector(self._dataframe, [Field(pattern=f"**/{f}") for f in fields])
 
     class _PseudoFunctionSelector:
@@ -73,7 +71,7 @@ class PseudoData:
             """Pseudonymize using the 'map-sid' pseudo function.
 
             This should only be used for Norwegian personal numbers for which we wish
-            to first map the personal number to an SSB "Stable identifier" (sid)
+            to first map the personal number to an SSB "Stable identifier" (aka snr, sid)
             and subsequently pseudonymize the sid using Format Preserving Encryption.
             """
             pseudo_func = PseudoFunction(

--- a/src/dapla_pseudo/v1/builder.py
+++ b/src/dapla_pseudo/v1/builder.py
@@ -5,8 +5,8 @@ from dataclasses import dataclass
 import pandas as pd
 import requests
 
-from dapla_pseudo.constants import predefined_keys
-from dapla_pseudo.constants import pseudo_function_types
+from dapla_pseudo.constants import PredefinedKeys
+from dapla_pseudo.constants import PseudoFunctionTypes
 from dapla_pseudo.v1.models import Field
 from dapla_pseudo.v1.models import KeyWrapper
 from dapla_pseudo.v1.models import Mimetypes
@@ -51,7 +51,7 @@ class Dataset:
             self._dataframe: pd.DataFrame = dataframe
             self._field: Field = field
             self._pseudo_func: PseudoFunction = PseudoFunction(
-                function_type=pseudo_function_types.DAEAD, key=predefined_keys.SSB_COMMON_KEY_1
+                function_type=PseudoFunctionTypes.DAEAD, key=PredefinedKeys.SSB_COMMON_KEY_1
             )
 
         def map_to_sid(self) -> "Dataset._Pseudonymizer":
@@ -62,7 +62,7 @@ class Dataset:
             and subsequently pseudonymize the sid using Format Preserving Encryption.
             """
             self._pseudo_func = PseudoFunction(
-                function_type=pseudo_function_types.MAP_SID, key=predefined_keys.PAPIS_COMMON_KEY_1
+                function_type=PseudoFunctionTypes.MAP_SID, key=PredefinedKeys.PAPIS_COMMON_KEY_1
             )
             return self
 

--- a/src/dapla_pseudo/v1/builder.py
+++ b/src/dapla_pseudo/v1/builder.py
@@ -45,11 +45,11 @@ class PseudoData:
             """Initialize the class."""
             self._dataframe = dataframe
 
-        def on_field(self, field: str) -> "PseudoData._PseudoFunctionSelector":
+        def on_field(self, field: str) -> "PseudoData._Pseudonymizer":
             """Specify a single field to be pseudonymized."""
             return PseudoData._Pseudonymizer(self._dataframe, [Field(pattern=f"**/{field}")])
 
-        def on_fields(self, *fields: str) -> "PseudoData._PseudoFunctionSelector":
+        def on_fields(self, *fields: str) -> "PseudoData._Pseudonymizer":
             """Specify multiple fields to be pseudonymized."""
             return PseudoData._Pseudonymizer(self._dataframe, [Field(pattern=f"**/{f}") for f in fields])
 
@@ -66,7 +66,7 @@ class PseudoData:
             return self
 
         def pseudonymize(
-            self, preserve_formatting: bool = False, with_custom_function: PseudoFunction = None
+            self, preserve_formatting: bool = False, with_custom_function: Optional[PseudoFunction] = None
         ) -> "PseudonymizationResult":
             # If _pseudo_func has been defined upstream, then use that.
             if self._pseudo_func is None:
@@ -90,7 +90,9 @@ class PseudoData:
             return _do_pseudonymization(dataframe=self._dataframe, fields=self._fields, pseudo_func=self._pseudo_func)
 
 
-def _do_pseudonymization(dataframe: pd.DataFrame, fields: list[Field], pseudo_func: PseudoFunction):
+def _do_pseudonymization(
+    dataframe: pd.DataFrame, fields: list[Field], pseudo_func: PseudoFunction
+) -> "PseudonymizationResult":
     pseudonymize_request = PseudonymizeFileRequest(
         pseudo_config=PseudoConfig(
             rules=[

--- a/src/dapla_pseudo/v1/builder.py
+++ b/src/dapla_pseudo/v1/builder.py
@@ -1,6 +1,7 @@
 """Builder for submitting a pseudonymization request."""
 
 from dataclasses import dataclass
+from typing import Optional
 
 import pandas as pd
 import requests
@@ -25,7 +26,7 @@ class PseudonymizationResult:
     dataframe: pd.DataFrame
 
 
-class Dataset:
+class PseudoData:
     """Starting point for pseudonymizing a single field.
 
     This class should not be instantiated, only the static methods should be used.
@@ -33,43 +34,92 @@ class Dataset:
 
     @staticmethod
     def from_pandas(dataframe: pd.DataFrame) -> "_FieldSelector":
-        """Initialize a pseudonymization request from a pandas DataFrame"""
-        return Dataset._FieldSelector(dataframe)
+        """Initialize a pseudonymization request from a pandas DataFrame."""
+        return PseudoData._FieldSelector(dataframe)
+
+    @staticmethod
+    def from_bucket(bucket_uri: str) -> "_FieldSelector":
+        """Initialize a pseudonymization request from a csv or json file in a bucket."""
+        raise NotImplementedError()
 
     class _FieldSelector:
+        """Select one or multiple fields to be pseudonymized."""
+
         def __init__(self, dataframe: pd.DataFrame):
             """Initialize the class."""
             self._dataframe = dataframe
 
-        def on_field(self, field: str) -> "Dataset._Pseudonymizer":
+        def on_field(self, field: str) -> "PseudoData._PseudoFunctionSelector":
             """Specify the field to be pseudonymized"""
             # Extract/specify field
-            return Dataset._Pseudonymizer(self._dataframe, Field(pattern=f"**/{field}"))
+            return PseudoData._PseudoFunctionSelector(self._dataframe, [Field(pattern=f"**/{field}")])
 
-    class _Pseudonymizer:
-        def __init__(self, dataframe: pd.DataFrame, field: Field) -> None:
+        def on_fields(self, *fields: str) -> "PseudoData._PseudoFunctionSelector":
+            """Specify the field to be pseudonymized"""
+            # Extract/specify field
+            return PseudoData._PseudoFunctionSelector(self._dataframe, [Field(pattern=f"**/{f}") for f in fields])
+
+    class _PseudoFunctionSelector:
+        def __init__(self, dataframe: pd.DataFrame, fields: list[Field]) -> None:
             self._dataframe: pd.DataFrame = dataframe
-            self._field: Field = field
-            self._pseudo_func: PseudoFunction = PseudoFunction(
-                function_type=PseudoFunctionTypes.DAEAD, key=PredefinedKeys.SSB_COMMON_KEY_1
-            )
+            self._fields: list[Field] = fields
 
-        def map_to_sid(self) -> "Dataset._Pseudonymizer":
-            """Specify use of the 'map-sid' pseudo function.
+        def apply_default_encryption(self) -> "PseudoData._Pseudonymizer":
+            """Pseudonymize using the 'daead' pseudo function."""
+            pseudo_func = PseudoFunction(function_type=PseudoFunctionTypes.DAEAD, key=PredefinedKeys.SSB_COMMON_KEY_1)
+            return PseudoData._Pseudonymizer(self._dataframe, self._fields, pseudo_func)
+
+        def map_to_stable_id_then_apply_fpe(self) -> "PseudoData._Pseudonymizer":
+            """Pseudonymize using the 'map-sid' pseudo function.
 
             This should only be used for Norwegian personal numbers for which we wish
             to first map the personal number to an SSB "Stable identifier" (sid)
             and subsequently pseudonymize the sid using Format Preserving Encryption.
             """
-            self._pseudo_func = PseudoFunction(
+            pseudo_func = PseudoFunction(
                 function_type=PseudoFunctionTypes.MAP_SID, key=PredefinedKeys.PAPIS_COMMON_KEY_1
             )
-            return self
+            return PseudoData._Pseudonymizer(self._dataframe, self._fields, pseudo_func)
+
+        def apply_fpe(self) -> "PseudoData._Pseudonymizer":
+            """Pseudonymize using the 'ff31' pseudo function.
+
+            This should be used for Stable IDs (snr) which must be compatible with pseudonyms created on-prem.
+            """
+            pseudo_func = PseudoFunction(
+                function_type=PseudoFunctionTypes.FF31,
+                key=PredefinedKeys.PAPIS_COMMON_KEY_1,
+                extra_kwargs=["strategy=SKIP"],
+            )
+            return PseudoData._Pseudonymizer(self._dataframe, self._fields, pseudo_func)
+
+        def apply_custom_pseudo_function(
+            self,
+            function_type: str | PseudoFunctionTypes,
+            key: str | PredefinedKeys,
+            extra_kwargs: Optional[list[str]] = None,
+        ) -> "PseudoData._Pseudonymizer":
+            """Pseudonymize using the specified pseudo function."""
+            pseudo_func = PseudoFunction(function_type=function_type, key=key, extra_kwargs=extra_kwargs)
+            return PseudoData._Pseudonymizer(self._dataframe, self._fields, pseudo_func)
+
+    class _Pseudonymizer:
+        def __init__(self, dataframe: pd.DataFrame, fields: list[Field], pseudo_func: PseudoFunction) -> None:
+            self._dataframe: pd.DataFrame = dataframe
+            self._fields: list[Field] = fields
+            self._pseudo_func: PseudoFunction = pseudo_func
 
         def pseudonymize(self) -> "PseudonymizationResult":
             pseudonymize_request = PseudonymizeFileRequest(
                 pseudo_config=PseudoConfig(
-                    rules=[PseudoRule(pattern=self._field.pattern, func=str(self._pseudo_func))],
+                    rules=[
+                        PseudoRule(
+                            name=f"{f.pattern.split('/')[-1]}-{self._pseudo_func}",
+                            pattern=f.pattern,
+                            func=str(self._pseudo_func),
+                        )
+                        for f in self._fields
+                    ],
                     keysets=KeyWrapper(self._pseudo_func.key).keyset_list(),
                 ),
                 target_content_type=Mimetypes.JSON,

--- a/src/dapla_pseudo/v1/builder.py
+++ b/src/dapla_pseudo/v1/builder.py
@@ -1,0 +1,82 @@
+"""Builder for submitting a pseudonymization request."""
+
+from dataclasses import dataclass
+
+import pandas as pd
+import requests
+
+from dapla_pseudo.constants import predefined_keys
+from dapla_pseudo.constants import pseudo_function_types
+from dapla_pseudo.v1.models import Field
+from dapla_pseudo.v1.models import KeyWrapper
+from dapla_pseudo.v1.models import Mimetypes
+from dapla_pseudo.v1.models import PseudoConfig
+from dapla_pseudo.v1.models import PseudoFunction
+from dapla_pseudo.v1.models import PseudonymizeFileRequest
+from dapla_pseudo.v1.models import PseudoRule
+from dapla_pseudo.v1.ops import _client
+from dapla_pseudo.v1.ops import _dataframe_to_json
+
+
+@dataclass
+class PseudonymizationResult:
+    """Holder for data and metadata returned from pseudo-service"""
+
+    dataframe: pd.DataFrame
+
+
+class Dataset:
+    """Starting point for pseudonymizing a single field.
+
+    This class should not be instantiated, only the static methods should be used.
+    """
+
+    @staticmethod
+    def from_pandas(dataframe: pd.DataFrame) -> "_FieldSelector":
+        """Initialize a pseudonymization request from a pandas DataFrame"""
+        return Dataset._FieldSelector(dataframe)
+
+    class _FieldSelector:
+        def __init__(self, dataframe: pd.DataFrame):
+            """Initialize the class."""
+            self._dataframe = dataframe
+
+        def on_field(self, field: str) -> "Dataset._Pseudonymizer":
+            """Specify the field to be pseudonymized"""
+            # Extract/specify field
+            return Dataset._Pseudonymizer(self._dataframe, Field(pattern=f"**/{field}"))
+
+    class _Pseudonymizer:
+        def __init__(self, dataframe: pd.DataFrame, field: Field) -> None:
+            self._dataframe: pd.DataFrame = dataframe
+            self._field: Field = field
+            self._pseudo_func: PseudoFunction = PseudoFunction(
+                function_type=pseudo_function_types.DAEAD, key=predefined_keys.SSB_COMMON_KEY_1
+            )
+
+        def map_to_sid(self) -> "Dataset._Pseudonymizer":
+            """Specify use of the 'map-sid' pseudo function.
+
+            This should only be used for Norwegian personal numbers for which we wish
+            to first map the personal number to an SSB "Stable identifier" (sid)
+            and subsequently pseudonymize the sid using Format Preserving Encryption.
+            """
+            self._pseudo_func = PseudoFunction(
+                function_type=pseudo_function_types.MAP_SID, key=predefined_keys.PAPIS_COMMON_KEY_1
+            )
+            return self
+
+        def pseudonymize(self) -> "PseudonymizationResult":
+            pseudonymize_request = PseudonymizeFileRequest(
+                pseudo_config=PseudoConfig(
+                    rules=[PseudoRule(pattern=self._field.pattern, func=str(self._pseudo_func))],
+                    keysets=KeyWrapper(self._pseudo_func.key).keyset_list(),
+                ),
+                target_content_type=Mimetypes.JSON,
+                target_uri=None,
+                compression=None,
+            )
+            response: requests.Response = _client().pseudonymize(
+                pseudonymize_request, _dataframe_to_json(self._dataframe), stream=True
+            )
+            return PseudonymizationResult(dataframe=pd.json_normalize(response.json()))

--- a/src/dapla_pseudo/v1/builder.py
+++ b/src/dapla_pseudo/v1/builder.py
@@ -27,7 +27,7 @@ class PseudonymizationResult:
 
 
 class PseudoData:
-    """Starting point for pseudonymizing a single field.
+    """Starting point for pseudonymization of datasets.
 
     This class should not be instantiated, only the static methods should be used.
     """
@@ -36,11 +36,6 @@ class PseudoData:
     def from_pandas(dataframe: pd.DataFrame) -> "_FieldSelector":
         """Initialize a pseudonymization request from a pandas DataFrame."""
         return PseudoData._FieldSelector(dataframe)
-
-    @staticmethod
-    def from_bucket(bucket_uri: str) -> "_FieldSelector":
-        """Initialize a pseudonymization request from a csv or json file in a bucket."""
-        raise NotImplementedError()
 
     class _FieldSelector:
         """Select one or multiple fields to be pseudonymized."""

--- a/src/dapla_pseudo/v1/models.py
+++ b/src/dapla_pseudo/v1/models.py
@@ -2,6 +2,7 @@
 import json
 import typing as t
 from enum import Enum
+from typing import Optional
 
 from pydantic import BaseModel
 
@@ -143,7 +144,8 @@ class PseudoFunction(BaseModel):
 
     function_type: str
     key: str
+    extra_kwargs: Optional[list[str]] = None
 
     def __str__(self) -> str:
-        """Function representation as expected by pseudo service."""
-        return f"{self.function_type}(keyId={self.key})"
+        """Create the function representation as expected by pseudo service."""
+        return f"{self.function_type}({', '.join([f'keyId={self.key}'] + (self.extra_kwargs or []))})"

--- a/src/dapla_pseudo/v1/models.py
+++ b/src/dapla_pseudo/v1/models.py
@@ -133,3 +133,17 @@ class KeyWrapper(BaseModel):
     def keyset_list(self) -> t.Union[t.List[PseudoKeyset], None]:
         """Wrap the keyset in a list if it is defined - or return None if it is not."""
         return None if self.keyset is None else [self.keyset]
+
+
+class PseudoFunction(BaseModel):
+    """Formal representation of a pseudo function.
+
+    Use to build up the string representation expected by pseudo service
+    """
+
+    function_type: str
+    key: str
+
+    def __str__(self) -> str:
+        """Function representation as expected by pseudo service."""
+        return f"{self.function_type}(keyId={self.key})"

--- a/src/dapla_pseudo/v1/ops.py
+++ b/src/dapla_pseudo/v1/ops.py
@@ -272,11 +272,11 @@ def _content_type_of(file_path: str) -> str:
 
 def _dataframe_to_json(
     data: pd.DataFrame,
-    fields: t.List[_FieldDecl],
+    fields: t.Optional[t.List[_FieldDecl]] = None,
     sid_fields: t.Optional[t.List[str]] = None,
 ) -> t.BinaryIO:
     # Ensure fields to be pseudonymized are string type
-    for field in set(fields).union(sid_fields or []):
+    for field in set(fields or []).union(sid_fields or []):
         data[field] = data[field].apply(str)
 
     file_handle = io.BytesIO()

--- a/src/dapla_pseudo/v1/ops.py
+++ b/src/dapla_pseudo/v1/ops.py
@@ -20,8 +20,8 @@ import magic
 import pandas as pd
 import requests
 
-from dapla_pseudo.constants import env
-from dapla_pseudo.constants import predefined_keys
+from dapla_pseudo.constants import Env
+from dapla_pseudo.constants import PredefinedKeys
 
 from ..types import _BinaryFileDecl
 from ..types import _DatasetDecl
@@ -42,7 +42,7 @@ def pseudonymize(
     dataset: _DatasetDecl,
     fields: t.Optional[t.List[_FieldDecl]] = None,
     sid_fields: t.Optional[t.List[str]] = None,
-    key: t.Union[str, PseudoKeyset] = predefined_keys.SSB_COMMON_KEY_1,
+    key: t.Union[str, PseudoKeyset] = PredefinedKeys.SSB_COMMON_KEY_1,
     stream: bool = True,
 ) -> requests.Response:
     """Pseudonymize specified fields of a dataset.
@@ -126,7 +126,7 @@ def pseudonymize(
 def depseudonymize(
     file_path: str,
     fields: t.List[_FieldDecl],
-    key: t.Union[str, PseudoKeyset] = predefined_keys.SSB_COMMON_KEY_1,
+    key: t.Union[str, PseudoKeyset] = PredefinedKeys.SSB_COMMON_KEY_1,
     stream: bool = True,
 ) -> requests.Response:
     """Depseudonymize specified fields of a local file.
@@ -178,8 +178,8 @@ def depseudonymize(
 def repseudonymize(
     file_path: str,
     fields: t.List[_FieldDecl],
-    source_key: t.Union[str, PseudoKeyset] = predefined_keys.SSB_COMMON_KEY_1,
-    target_key: t.Union[str, PseudoKeyset] = predefined_keys.SSB_COMMON_KEY_1,
+    source_key: t.Union[str, PseudoKeyset] = PredefinedKeys.SSB_COMMON_KEY_1,
+    target_key: t.Union[str, PseudoKeyset] = PredefinedKeys.SSB_COMMON_KEY_1,
     stream: bool = True,
 ) -> requests.Response:
     """Repseudonymize specified fields of a local, previously pseudonymized file.
@@ -234,8 +234,8 @@ def repseudonymize(
 
 def _client() -> PseudoClient:
     return PseudoClient(
-        pseudo_service_url=os.getenv(env.PSEUDO_SERVICE_URL),
-        auth_token=os.getenv(env.PSEUDO_SERVICE_AUTH_TOKEN),
+        pseudo_service_url=os.getenv(Env.PSEUDO_SERVICE_URL),
+        auth_token=os.getenv(Env.PSEUDO_SERVICE_AUTH_TOKEN),
     )
 
 
@@ -245,7 +245,7 @@ def _rules_of(fields: t.List[_FieldDecl], sid_fields: t.List[str], key: str) -> 
 
 
 def _rule_of(f: _FieldDecl, n: int, k: str) -> PseudoRule:
-    key = predefined_keys.SSB_COMMON_KEY_1 if k is None else k
+    key = PredefinedKeys.SSB_COMMON_KEY_1 if k is None else k
 
     if isinstance(f, Field):
         field = f
@@ -255,7 +255,7 @@ def _rule_of(f: _FieldDecl, n: int, k: str) -> PseudoRule:
         field = Field(pattern=f"**/{f}")
 
     if field.mapping == "sid":
-        func = f"map-sid(keyId={predefined_keys.PAPIS_COMMON_KEY_1})"
+        func = f"map-sid(keyId={PredefinedKeys.PAPIS_COMMON_KEY_1})"
     else:
         func = f"daead(keyId={key})"
 

--- a/src/dapla_pseudo/v1/ops.py
+++ b/src/dapla_pseudo/v1/ops.py
@@ -272,8 +272,8 @@ def _content_type_of(file_path: str) -> str:
 
 def _dataframe_to_json(
     data: pd.DataFrame,
-    fields: t.Optional[t.List[_FieldDecl]] = None,
-    sid_fields: t.Optional[t.List[str]] = None,
+    fields: t.Optional[t.Sequence[_FieldDecl]] = None,
+    sid_fields: t.Optional[t.Sequence[str]] = None,
 ) -> t.BinaryIO:
     # Ensure fields to be pseudonymized are string type
     for field in set(fields or []).union(sid_fields or []):

--- a/tests/builder_examples.ipynb
+++ b/tests/builder_examples.ipynb
@@ -1,0 +1,156 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "fcc3b381-e9a8-4376-946f-d5aae4c7844f",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "from io import StringIO\n",
+    "from pathlib import Path\n",
+    "\n",
+    "from dapla_pseudo import PseudoData\n",
+    "import pandas as pd\n",
+    "\n",
+    "JSON_FILE = \"data/personer.json\"\n",
+    "CSV_FILE = \"data/personer.csv\"\n",
+    "\n",
+    "df = pd.read_json(\n",
+    "    JSON_FILE,\n",
+    "    dtype={\n",
+    "        \"fnr\": \"string\",\n",
+    "        \"fornavn\": \"string\",\n",
+    "        \"etternavn\": \"string\",\n",
+    "        \"kjonn\": \"category\",\n",
+    "        \"fodselsdato\": \"string\",\n",
+    "    },\n",
+    ")\n",
+    "df.head()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "11a6cb10-568c-464b-b6a1-886e29f4eba1",
+   "metadata": {},
+   "source": [
+    "# Case: Single field default encryption (daead)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "552106c1-3824-47ca-9566-4dd34ef8f79a",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "result = (\n",
+    "    PseudoData.from_pandas(df).on_field(\"fnr\").apply_default_encryption().pseudonymize()\n",
+    ")\n",
+    "result.dataframe.head()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0953789f-1ed6-4f74-919b-b92fde89a916",
+   "metadata": {},
+   "source": [
+    "# Case: Single field sid mapping"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "070c3567-ed55-4a10-8891-d5baaa8dec8b",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "result = (\n",
+    "    PseudoData.from_pandas(df)\n",
+    "    .on_field(\"fnr\")\n",
+    "    .map_to_stable_id_then_apply_fpe()\n",
+    "    .pseudonymize()\n",
+    ")\n",
+    "result.dataframe.head()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c8410675-a26f-4b6c-98c9-04108c82b474",
+   "metadata": {},
+   "source": [
+    "# Case: Multiple fields default encryption (daead)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a43308ab-7418-4c7b-900f-f222a66b3d9f",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "result = (\n",
+    "    PseudoData.from_pandas(df)\n",
+    "    .on_fields(\"fornavn\", \"etternavn\", \"fodselsdato\")\n",
+    "    .apply_default_encryption()\n",
+    "    .pseudonymize()\n",
+    ")\n",
+    "result.dataframe.head()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "74948ca1-66a2-42f7-ba81-05480fcc964b",
+   "metadata": {},
+   "source": [
+    "# Case: Chaining calls\n",
+    "Calls may simply be chained together to apply different pseudonymization to different fields."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ec81dd18-5f90-4262-8603-7073e89f6527",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "result = (\n",
+    "    PseudoData.from_pandas(df)\n",
+    "    .on_field(\"fnr\")\n",
+    "    .map_to_stable_id_then_apply_fpe()\n",
+    "    .pseudonymize()\n",
+    ")\n",
+    "result = (\n",
+    "    PseudoData.from_pandas(result.dataframe)\n",
+    "    .on_fields(\"fornavn\", \"etternavn\", \"fodselsdato\")\n",
+    "    .apply_default_encryption()\n",
+    "    .pseudonymize()\n",
+    ")\n",
+    "result.dataframe.head()"
+   ]
+  }
+ ],
+ "metadata": {
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython"
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/tests/builder_examples.ipynb
+++ b/tests/builder_examples.ipynb
@@ -49,7 +49,7 @@
    "outputs": [],
    "source": [
     "result = (\n",
-    "    PseudoData.from_pandas(df).on_field(\"fnr\").apply_default_encryption().pseudonymize()\n",
+    "    PseudoData.from_pandas(df).on_field(\"fnr\").pseudonymize()\n",
     ")\n",
     "result.dataframe.head()"
    ]
@@ -74,8 +74,33 @@
     "result = (\n",
     "    PseudoData.from_pandas(df)\n",
     "    .on_field(\"fnr\")\n",
-    "    .map_to_stable_id_then_apply_fpe()\n",
+    "    .map_to_stable_id()\n",
     "    .pseudonymize()\n",
+    ")\n",
+    "result.dataframe.head()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "69689655-f2f2-4d4a-a4fe-5f031c65aaf0",
+   "metadata": {},
+   "source": [
+    "# Case: Single field FPE (used for e.g. existing stable ID/snr/sid)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ad3ef370-82f2-4993-9f0d-164bb40d4334",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "result = (\n",
+    "    PseudoData.from_pandas(df)\n",
+    "    .on_field(\"fnr\")\n",
+    "    .pseudonymize(preserve_formatting=True)\n",
     ")\n",
     "result.dataframe.head()"
    ]
@@ -100,7 +125,6 @@
     "result = (\n",
     "    PseudoData.from_pandas(df)\n",
     "    .on_fields(\"fornavn\", \"etternavn\", \"fodselsdato\")\n",
-    "    .apply_default_encryption()\n",
     "    .pseudonymize()\n",
     ")\n",
     "result.dataframe.head()"
@@ -127,13 +151,12 @@
     "result = (\n",
     "    PseudoData.from_pandas(df)\n",
     "    .on_field(\"fnr\")\n",
-    "    .map_to_stable_id_then_apply_fpe()\n",
+    "    .map_to_stable_id()\n",
     "    .pseudonymize()\n",
     ")\n",
     "result = (\n",
     "    PseudoData.from_pandas(result.dataframe)\n",
     "    .on_fields(\"fornavn\", \"etternavn\", \"fodselsdato\")\n",
-    "    .apply_default_encryption()\n",
     "    .pseudonymize()\n",
     ")\n",
     "result.dataframe.head()"

--- a/tests/pseudonymize_examples.ipynb
+++ b/tests/pseudonymize_examples.ipynb
@@ -131,22 +131,14 @@
   }
  ],
  "metadata": {
-  "kernelspec": {
-   "display_name": "pseudo",
-   "language": "python",
-   "name": "pseudo"
-  },
   "language_info": {
    "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
+    "name": "ipython"
    },
    "file_extension": ".py",
    "mimetype": "text/x-python",
    "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.10.9"
+   "nbconvert_exporter": "python"
   }
  },
  "nbformat": 4,

--- a/tests/v1/test_builder.py
+++ b/tests/v1/test_builder.py
@@ -1,0 +1,22 @@
+from unittest.mock import Mock
+from unittest.mock import patch
+
+import pandas as pd
+import pytest
+import requests
+
+from dapla_pseudo.v1.builder import Dataset
+
+
+PKG = "dapla_pseudo.v1.builder"
+
+
+@pytest.fixture()
+def df() -> pd.DataFrame:
+    return pd.DataFrame()
+
+
+@patch(f"{PKG}._client")
+def test_pandas_pseudonymize_minimal_call(patched_client: Mock, df: pd.DataFrame):
+    patched_client.pseudonymize.return_value = requests.Response()
+    Dataset.from_pandas(df).on_field("").pseudonymize()

--- a/tests/v1/test_builder.py
+++ b/tests/v1/test_builder.py
@@ -1,3 +1,4 @@
+import json
 from unittest.mock import Mock
 from unittest.mock import patch
 
@@ -17,7 +18,8 @@ PKG = "dapla_pseudo.v1.builder"
 
 @pytest.fixture()
 def df() -> pd.DataFrame:
-    return pd.DataFrame({"a": ["1", "2", "3"]})
+    with open("tests/data/personer.json") as test_data:
+        return pd.json_normalize(json.load(test_data))
 
 
 @patch(f"{PKG}._client")
@@ -26,18 +28,39 @@ def test_builder_pandas_pseudonymize_minimal_call(patched_client: Mock, df: pd.D
     PseudoData.from_pandas(df).on_field("fornavn").apply_default_encryption()
 
 
-def test_builder_pandas_pseudo_func_default(df: pd.DataFrame) -> None:
+def test_builder_fields_selector_single_field(df: pd.DataFrame) -> None:
+    PseudoData.from_pandas(df).on_field("fornavn")._fields = [Field(pattern="**/fornavn")]
+
+
+def test_builder_fields_selector_multiple_fields(df: pd.DataFrame) -> None:
+    PseudoData.from_pandas(df).on_fields("fornavn", "fnr")._fields = [
+        Field(pattern="**/fornavn"),
+        Field(pattern="**/fnr"),
+    ]
+
+
+def test_builder_pseudo_function_selector_default(df: pd.DataFrame) -> None:
     assert PseudoData.from_pandas(df).on_field("fornavn").apply_default_encryption()._pseudo_func == PseudoFunction(
         function_type=PseudoFunctionTypes.DAEAD, key=PredefinedKeys.SSB_COMMON_KEY_1
     )
 
 
-def test_builder_pandas_pseudo_func_map_to_sid(df: pd.DataFrame) -> None:
-    assert PseudoData.from_pandas(df).on_field(
-        "fornavn"
-    ).map_to_stable_id_then_apply_fpe()._pseudo_func == PseudoFunction(
+def test_builder_pseudo_function_selector_map_to_sid(df: pd.DataFrame) -> None:
+    assert PseudoData.from_pandas(df).on_field("fnr").map_to_stable_id_then_apply_fpe()._pseudo_func == PseudoFunction(
         function_type=PseudoFunctionTypes.MAP_SID, key=PredefinedKeys.PAPIS_COMMON_KEY_1
     )
+
+
+def test_builder_pseudo_function_selector_fpe(df: pd.DataFrame) -> None:
+    assert PseudoData.from_pandas(df).on_field("fnr").apply_fpe()._pseudo_func == PseudoFunction(
+        function_type=PseudoFunctionTypes.FF31, key=PredefinedKeys.PAPIS_COMMON_KEY_1, extra_kwargs=["strategy=SKIP"]
+    )
+
+
+def test_builder_pseudo_function_selector_custom(df: pd.DataFrame) -> None:
+    assert PseudoData.from_pandas(df).on_field("fnr").apply_custom_pseudo_function(
+        PseudoFunctionTypes.FF31, PredefinedKeys.SSB_COMMON_KEY_2
+    )._pseudo_func == PseudoFunction(function_type=PseudoFunctionTypes.FF31, key=PredefinedKeys.SSB_COMMON_KEY_2)
 
 
 def test_builder_pandas_pseudo_func_multiple_fields(df: pd.DataFrame) -> None:
@@ -46,4 +69,4 @@ def test_builder_pandas_pseudo_func_multiple_fields(df: pd.DataFrame) -> None:
 
 
 def test_builder_bucket() -> None:
-    PseudoData.from_bucket("gs://my-bucket")
+    PseudoData.from_bucket("gs://my-bucket/my-data.csv")

--- a/tests/v1/test_builder.py
+++ b/tests/v1/test_builder.py
@@ -25,7 +25,7 @@ def df() -> pd.DataFrame:
 @patch(f"{PKG}._client")
 def test_builder_pandas_pseudonymize_minimal_call(patched_client: Mock, df: pd.DataFrame) -> None:
     patched_client.pseudonymize.return_value = requests.Response()
-    PseudoData.from_pandas(df).on_field("fornavn").apply_default_encryption()
+    PseudoData.from_pandas(df).on_field("fornavn").apply_default_encryption().pseudonymize()
 
 
 def test_builder_fields_selector_single_field(df: pd.DataFrame) -> None:
@@ -66,7 +66,3 @@ def test_builder_pseudo_function_selector_custom(df: pd.DataFrame) -> None:
 def test_builder_pandas_pseudo_func_multiple_fields(df: pd.DataFrame) -> None:
     fields = ["snr", "snr_mor", "snr_far"]
     assert PseudoData.from_pandas(df).on_fields(*fields)._fields == [Field(pattern=f"**/{f}") for f in fields]
-
-
-def test_builder_bucket() -> None:
-    PseudoData.from_bucket("gs://my-bucket/my-data.csv")

--- a/tests/v1/test_builder.py
+++ b/tests/v1/test_builder.py
@@ -1,4 +1,5 @@
 import json
+from unittest.mock import MagicMock
 from unittest.mock import Mock
 from unittest.mock import patch
 
@@ -25,7 +26,7 @@ def df() -> pd.DataFrame:
 @patch(f"{PKG}._client")
 def test_builder_pandas_pseudonymize_minimal_call(patched_client: Mock, df: pd.DataFrame) -> None:
     patched_client.pseudonymize.return_value = requests.Response()
-    PseudoData.from_pandas(df).on_field("fornavn").apply_default_encryption().pseudonymize()
+    PseudoData.from_pandas(df).on_field("fornavn").pseudonymize()
 
 
 def test_builder_fields_selector_single_field(df: pd.DataFrame) -> None:
@@ -39,30 +40,52 @@ def test_builder_fields_selector_multiple_fields(df: pd.DataFrame) -> None:
     ]
 
 
-def test_builder_pseudo_function_selector_default(df: pd.DataFrame) -> None:
-    assert PseudoData.from_pandas(df).on_field("fornavn").apply_default_encryption()._pseudo_func == PseudoFunction(
-        function_type=PseudoFunctionTypes.DAEAD, key=PredefinedKeys.SSB_COMMON_KEY_1
+@patch(f"{PKG}._do_pseudonymization")
+def test_builder_pseudo_function_selector_default(patch_do_pseudonymization: MagicMock, df: pd.DataFrame) -> None:
+    PseudoData.from_pandas(df).on_field("fornavn").pseudonymize()
+    patch_do_pseudonymization.assert_called_once_with(
+        dataframe=df,
+        fields=[Field(pattern="**/fornavn")],
+        pseudo_func=PseudoFunction(function_type=PseudoFunctionTypes.DAEAD, key=PredefinedKeys.SSB_COMMON_KEY_1),
     )
 
 
-def test_builder_pseudo_function_selector_map_to_sid(df: pd.DataFrame) -> None:
-    assert PseudoData.from_pandas(df).on_field("fnr").map_to_stable_id_then_apply_fpe()._pseudo_func == PseudoFunction(
-        function_type=PseudoFunctionTypes.MAP_SID, key=PredefinedKeys.PAPIS_COMMON_KEY_1
+@patch(f"{PKG}._do_pseudonymization")
+def test_builder_pseudo_function_selector_map_to_sid(patch_do_pseudonymization: MagicMock, df: pd.DataFrame) -> None:
+    PseudoData.from_pandas(df).on_field("fnr").map_to_stable_id().pseudonymize()
+    patch_do_pseudonymization.assert_called_once_with(
+        dataframe=df,
+        fields=[Field(pattern="**/fnr")],
+        pseudo_func=PseudoFunction(function_type=PseudoFunctionTypes.MAP_SID, key=PredefinedKeys.PAPIS_COMMON_KEY_1),
     )
 
 
-def test_builder_pseudo_function_selector_fpe(df: pd.DataFrame) -> None:
-    assert PseudoData.from_pandas(df).on_field("fnr").apply_fpe()._pseudo_func == PseudoFunction(
-        function_type=PseudoFunctionTypes.FF31, key=PredefinedKeys.PAPIS_COMMON_KEY_1, extra_kwargs=["strategy=SKIP"]
+@patch(f"{PKG}._do_pseudonymization")
+def test_builder_pseudo_function_selector_fpe(patch_do_pseudonymization: MagicMock, df: pd.DataFrame) -> None:
+    PseudoData.from_pandas(df).on_field("fnr").pseudonymize(preserve_formatting=True)
+    patch_do_pseudonymization.assert_called_once_with(
+        dataframe=df,
+        fields=[Field(pattern="**/fnr")],
+        pseudo_func=PseudoFunction(
+            function_type=PseudoFunctionTypes.FF31,
+            key=PredefinedKeys.PAPIS_COMMON_KEY_1,
+            extra_kwargs=["strategy=SKIP"],
+        ),
     )
 
 
-def test_builder_pseudo_function_selector_custom(df: pd.DataFrame) -> None:
-    assert PseudoData.from_pandas(df).on_field("fnr").apply_custom_pseudo_function(
-        PseudoFunctionTypes.FF31, PredefinedKeys.SSB_COMMON_KEY_2
-    )._pseudo_func == PseudoFunction(function_type=PseudoFunctionTypes.FF31, key=PredefinedKeys.SSB_COMMON_KEY_2)
+@patch(f"{PKG}._do_pseudonymization")
+def test_builder_pseudo_function_selector_custom(patch_do_pseudonymization: MagicMock, df: pd.DataFrame) -> None:
+    pseudo_func = PseudoFunction(function_type=PseudoFunctionTypes.FF31, key=PredefinedKeys.SSB_COMMON_KEY_2)
+    PseudoData.from_pandas(df).on_field("fnr").pseudonymize(with_custom_function=pseudo_func)
+
+    patch_do_pseudonymization.assert_called_once_with(
+        dataframe=df,
+        fields=[Field(pattern="**/fnr")],
+        pseudo_func=pseudo_func,
+    )
 
 
-def test_builder_pandas_pseudo_func_multiple_fields(df: pd.DataFrame) -> None:
+def test_builder_field_selector_multiple_fields(df: pd.DataFrame) -> None:
     fields = ["snr", "snr_mor", "snr_far"]
     assert PseudoData.from_pandas(df).on_fields(*fields)._fields == [Field(pattern=f"**/{f}") for f in fields]

--- a/tests/v1/test_builder.py
+++ b/tests/v1/test_builder.py
@@ -5,7 +5,11 @@ import pandas as pd
 import pytest
 import requests
 
-from dapla_pseudo.v1.builder import Dataset
+from dapla_pseudo.constants import PredefinedKeys
+from dapla_pseudo.constants import PseudoFunctionTypes
+from dapla_pseudo.v1.builder import PseudoData
+from dapla_pseudo.v1.models import Field
+from dapla_pseudo.v1.models import PseudoFunction
 
 
 PKG = "dapla_pseudo.v1.builder"
@@ -13,10 +17,33 @@ PKG = "dapla_pseudo.v1.builder"
 
 @pytest.fixture()
 def df() -> pd.DataFrame:
-    return pd.DataFrame()
+    return pd.DataFrame({"a": ["1", "2", "3"]})
 
 
 @patch(f"{PKG}._client")
-def test_pandas_pseudonymize_minimal_call(patched_client: Mock, df: pd.DataFrame):
+def test_builder_pandas_pseudonymize_minimal_call(patched_client: Mock, df: pd.DataFrame) -> None:
     patched_client.pseudonymize.return_value = requests.Response()
-    Dataset.from_pandas(df).on_field("").pseudonymize()
+    PseudoData.from_pandas(df).on_field("fornavn").apply_default_encryption()
+
+
+def test_builder_pandas_pseudo_func_default(df: pd.DataFrame) -> None:
+    assert PseudoData.from_pandas(df).on_field("fornavn").apply_default_encryption()._pseudo_func == PseudoFunction(
+        function_type=PseudoFunctionTypes.DAEAD, key=PredefinedKeys.SSB_COMMON_KEY_1
+    )
+
+
+def test_builder_pandas_pseudo_func_map_to_sid(df: pd.DataFrame) -> None:
+    assert PseudoData.from_pandas(df).on_field(
+        "fornavn"
+    ).map_to_stable_id_then_apply_fpe()._pseudo_func == PseudoFunction(
+        function_type=PseudoFunctionTypes.MAP_SID, key=PredefinedKeys.PAPIS_COMMON_KEY_1
+    )
+
+
+def test_builder_pandas_pseudo_func_multiple_fields(df: pd.DataFrame) -> None:
+    fields = ["snr", "snr_mor", "snr_far"]
+    assert PseudoData.from_pandas(df).on_fields(*fields)._fields == [Field(pattern=f"**/{f}") for f in fields]
+
+
+def test_builder_bucket() -> None:
+    PseudoData.from_bucket("gs://my-bucket")

--- a/tests/v1/test_depseudonymize.py
+++ b/tests/v1/test_depseudonymize.py
@@ -4,7 +4,7 @@ from unittest import mock
 import pytest
 
 from dapla_pseudo import depseudonymize
-from dapla_pseudo.constants import env
+from dapla_pseudo.constants import Env
 
 
 base_url = "https://mocked.dapla-pseudo-service"
@@ -12,8 +12,8 @@ auth_token = "some-auth-token"
 
 
 def test_depseudonymize_request_with_default_key(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setenv(env.PSEUDO_SERVICE_URL, base_url)
-    monkeypatch.setenv(env.PSEUDO_SERVICE_AUTH_TOKEN, auth_token)
+    monkeypatch.setenv(Env.PSEUDO_SERVICE_URL, base_url)
+    monkeypatch.setenv(Env.PSEUDO_SERVICE_AUTH_TOKEN, auth_token)
 
     with mock.patch("requests.post") as patched:
         depseudonymize(file_path="tests/data/personer.json", fields=["fnr", "fornavn"])

--- a/tests/v1/test_models.py
+++ b/tests/v1/test_models.py
@@ -1,6 +1,9 @@
 import json
 
+from dapla_pseudo.constants import PredefinedKeys
+from dapla_pseudo.constants import PseudoFunctionTypes
 from dapla_pseudo.v1.models import KeyWrapper
+from dapla_pseudo.v1.models import PseudoFunction
 from dapla_pseudo.v1.models import PseudoKeyset
 
 
@@ -49,3 +52,19 @@ def test_key_wrapper_with_keyset_json() -> None:
     key_wrapper = KeyWrapper(key=json.dumps(custom_keyset_dict))
     assert key_wrapper.key_id == "1234567890"
     assert key_wrapper.keyset == PseudoKeyset.parse_obj(custom_keyset_dict)
+
+
+def test_pseudo_function() -> None:
+    assert "daead(keyId=ssb-common-key-1)" == str(
+        PseudoFunction(function_type=PseudoFunctionTypes.DAEAD, key=PredefinedKeys.SSB_COMMON_KEY_1)
+    )
+
+
+def test_pseudo_function_with_extra_kwargs() -> None:
+    assert "ff31(keyId=papis-common-key-1, strategy=SKIP)" == str(
+        PseudoFunction(
+            function_type=PseudoFunctionTypes.FF31,
+            key=PredefinedKeys.PAPIS_COMMON_KEY_1,
+            extra_kwargs=["strategy=SKIP"],
+        )
+    )

--- a/tests/v1/test_ops.py
+++ b/tests/v1/test_ops.py
@@ -1,4 +1,6 @@
 import json
+from typing import Any
+from typing import Sequence
 
 import pandas as pd
 import pytest
@@ -76,21 +78,21 @@ def test_dataframe_to_json_minimal_call() -> None:
     ],
 )
 def test_dataframe_to_json_type_conversion(
-    input_dict: dict, expected_output: dict, fields: list[str], sid_fields: list[str]
+    input_dict: dict[str, Any], expected_output: dict[str, Any], fields: Sequence[str], sid_fields: Sequence[str]
 ) -> None:
     handle = _dataframe_to_json(pd.DataFrame(input_dict), fields=fields, sid_fields=sid_fields)
     assert expected_output == json.load(handle)
 
 
 @pytest.mark.parametrize(
-    "input_dict,expected_output,fields,sid_fields",
+    "input_dict,fields,sid_fields",
     [
-        ({"a": [1, 2, 3]}, [{"a": "1"}, {"a": "2"}, {"a": "3"}], None, ["b"]),
-        ({"a": [1, 2, 3]}, [{"a": "1"}, {"a": "2"}, {"a": "3"}], ["b"], None),
+        ({"a": [1, 2, 3]}, None, ["b"]),
+        ({"a": [1, 2, 3]}, ["b"], None),
     ],
 )
 def test_dataframe_to_json_unknown_field(
-    input_dict: dict, expected_output: dict, fields: list[str], sid_fields: list[str]
+    input_dict: dict[str, Any], fields: Sequence[str], sid_fields: Sequence[str]
 ) -> None:
     with pytest.raises(KeyError):
         _dataframe_to_json(pd.DataFrame(input_dict), fields=fields, sid_fields=sid_fields)

--- a/tests/v1/test_pseudonymize.py
+++ b/tests/v1/test_pseudonymize.py
@@ -8,8 +8,8 @@ import pytest
 from typeguard import suppress_type_checks
 
 from dapla_pseudo import pseudonymize
-from dapla_pseudo.constants import env
-from dapla_pseudo.constants import predefined_keys
+from dapla_pseudo.constants import Env
+from dapla_pseudo.constants import PredefinedKeys
 from dapla_pseudo.v1.models import Field
 from dapla_pseudo.v1.models import Mimetypes
 from dapla_pseudo.v1.models import PseudoKeyset
@@ -127,8 +127,8 @@ def test_pseudonymize_invalid_type(patched_auth_client: mock.Mock, test_data_jso
 def test_pseudonymize_request_with_default_key(
     patched_post: mock.Mock, monkeypatch: pytest.MonkeyPatch, test_data_json_file_path: str
 ) -> None:
-    monkeypatch.setenv(env.PSEUDO_SERVICE_URL, base_url)
-    monkeypatch.setenv(env.PSEUDO_SERVICE_AUTH_TOKEN, auth_token)
+    monkeypatch.setenv(Env.PSEUDO_SERVICE_URL, base_url)
+    monkeypatch.setenv(Env.PSEUDO_SERVICE_AUTH_TOKEN, auth_token)
 
     pseudonymize(test_data_json_file_path, fields=["fnr", "fornavn"])
     patched_post.assert_called_once()
@@ -158,15 +158,13 @@ def test_pseudonymize_request_with_default_key(
     assert arg["files"]["data"][2] == Mimetypes.JSON
 
 
-@pytest.mark.parametrize(
-    "key", [predefined_keys.SSB_COMMON_KEY_1, predefined_keys.SSB_COMMON_KEY_2, "some-unknown-key"]
-)
+@pytest.mark.parametrize("key", [PredefinedKeys.SSB_COMMON_KEY_1, PredefinedKeys.SSB_COMMON_KEY_2, "some-unknown-key"])
 @mock.patch(REQUESTS_POST)
 def test_pseudonymize_request_with_explicitly_specified_common_key(
     patched_post: mock.Mock, monkeypatch: pytest.MonkeyPatch, test_data_json_file_path: str, key: str
 ) -> None:
-    monkeypatch.setenv(env.PSEUDO_SERVICE_URL, base_url)
-    monkeypatch.setenv(env.PSEUDO_SERVICE_AUTH_TOKEN, auth_token)
+    monkeypatch.setenv(Env.PSEUDO_SERVICE_URL, base_url)
+    monkeypatch.setenv(Env.PSEUDO_SERVICE_AUTH_TOKEN, auth_token)
 
     pseudonymize(test_data_json_file_path, fields=["fnr", "fornavn"], key=key)
     patched_post.assert_called_once()
@@ -195,8 +193,8 @@ def test_pseudonymize_request_with_explicitly_specified_common_key(
 def test_pseudonymize_request_with_explicitly_specified_keyset(
     patched_post: mock.Mock, monkeypatch: pytest.MonkeyPatch, test_data_json_file_path: str
 ) -> None:
-    monkeypatch.setenv(env.PSEUDO_SERVICE_URL, base_url)
-    monkeypatch.setenv(env.PSEUDO_SERVICE_AUTH_TOKEN, auth_token)
+    monkeypatch.setenv(Env.PSEUDO_SERVICE_URL, base_url)
+    monkeypatch.setenv(Env.PSEUDO_SERVICE_AUTH_TOKEN, auth_token)
 
     keyset = custom_keyset
 
@@ -244,8 +242,8 @@ def test_pseudonymize_request_with_explicitly_specified_keyset(
 def test_pseudonymize_request_with_sid(
     patched_post: mock.Mock, monkeypatch: pytest.MonkeyPatch, test_data_json_file_path: str
 ) -> None:
-    monkeypatch.setenv(env.PSEUDO_SERVICE_URL, base_url)
-    monkeypatch.setenv(env.PSEUDO_SERVICE_AUTH_TOKEN, auth_token)
+    monkeypatch.setenv(Env.PSEUDO_SERVICE_URL, base_url)
+    monkeypatch.setenv(Env.PSEUDO_SERVICE_AUTH_TOKEN, auth_token)
 
     pseudonymize(
         test_data_json_file_path,
@@ -278,8 +276,8 @@ def test_pseudonymize_request_with_sid(
 def test_pseudonymize_sid_fields_only(
     patched_post: mock.Mock, monkeypatch: pytest.MonkeyPatch, test_data_json_file_path: str
 ) -> None:
-    monkeypatch.setenv(env.PSEUDO_SERVICE_URL, base_url)
-    monkeypatch.setenv(env.PSEUDO_SERVICE_AUTH_TOKEN, auth_token)
+    monkeypatch.setenv(Env.PSEUDO_SERVICE_URL, base_url)
+    monkeypatch.setenv(Env.PSEUDO_SERVICE_AUTH_TOKEN, auth_token)
 
     pseudonymize(
         test_data_json_file_path,
@@ -315,8 +313,8 @@ def test_pseudonymize_no_fields_or_sid_fields_specified(test_data_json_file_path
 def test_pseudonymize_request_using_sid_fields_parameter(
     patched_post: mock.Mock, monkeypatch: pytest.MonkeyPatch, test_data_json_file_path: str
 ) -> None:
-    monkeypatch.setenv(env.PSEUDO_SERVICE_URL, base_url)
-    monkeypatch.setenv(env.PSEUDO_SERVICE_AUTH_TOKEN, auth_token)
+    monkeypatch.setenv(Env.PSEUDO_SERVICE_URL, base_url)
+    monkeypatch.setenv(Env.PSEUDO_SERVICE_AUTH_TOKEN, auth_token)
 
     pseudonymize(test_data_json_file_path, fields=["fornavn"], sid_fields=["fnr"])
     patched_post.assert_called_once()

--- a/tests/v1/test_repseudonymize.py
+++ b/tests/v1/test_repseudonymize.py
@@ -4,8 +4,8 @@ from unittest import mock
 import pytest
 
 from dapla_pseudo import repseudonymize
-from dapla_pseudo.constants import env
-from dapla_pseudo.constants import predefined_keys
+from dapla_pseudo.constants import Env
+from dapla_pseudo.constants import PredefinedKeys
 from dapla_pseudo.v1.models import PseudoKeyset
 
 
@@ -32,8 +32,8 @@ custom_keyset = PseudoKeyset.parse_obj(
 
 
 def test_repseudonymize_request_with_default_keys(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setenv(env.PSEUDO_SERVICE_URL, base_url)
-    monkeypatch.setenv(env.PSEUDO_SERVICE_AUTH_TOKEN, auth_token)
+    monkeypatch.setenv(Env.PSEUDO_SERVICE_URL, base_url)
+    monkeypatch.setenv(Env.PSEUDO_SERVICE_AUTH_TOKEN, auth_token)
 
     with mock.patch("requests.post") as patched:
         repseudonymize(file_path="tests/data/personer.json", fields=["fnr", "fornavn"])
@@ -66,15 +66,15 @@ def test_repseudonymize_request_with_default_keys(monkeypatch: pytest.MonkeyPatc
 
 
 def test_repseudonymize_request_with_explicitly_specified_common_key(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setenv(env.PSEUDO_SERVICE_URL, base_url)
-    monkeypatch.setenv(env.PSEUDO_SERVICE_AUTH_TOKEN, auth_token)
+    monkeypatch.setenv(Env.PSEUDO_SERVICE_URL, base_url)
+    monkeypatch.setenv(Env.PSEUDO_SERVICE_AUTH_TOKEN, auth_token)
 
     with mock.patch("requests.post") as patched:
         repseudonymize(
             file_path="tests/data/personer.json",
             fields=["fnr", "fornavn"],
-            source_key=predefined_keys.SSB_COMMON_KEY_1,
-            target_key=predefined_keys.SSB_COMMON_KEY_2,
+            source_key=PredefinedKeys.SSB_COMMON_KEY_1,
+            target_key=PredefinedKeys.SSB_COMMON_KEY_2,
         )
         patched.assert_called_once()
         arg = patched.call_args.kwargs
@@ -105,8 +105,8 @@ def test_repseudonymize_request_with_explicitly_specified_common_key(monkeypatch
 
 
 def test_repseudonymize_request_with_explicitly_specified_keyset(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setenv(env.PSEUDO_SERVICE_URL, base_url)
-    monkeypatch.setenv(env.PSEUDO_SERVICE_AUTH_TOKEN, auth_token)
+    monkeypatch.setenv(Env.PSEUDO_SERVICE_URL, base_url)
+    monkeypatch.setenv(Env.PSEUDO_SERVICE_AUTH_TOKEN, auth_token)
 
     with mock.patch("requests.post") as patched:
         repseudonymize(


### PR DESCRIPTION
This allows for simplified configuration of pseudonymization through a flow with named methods which may be suggested by an IDE.

* Support for common pseudonymization use cases with specific methods.
* Support for custom pseudo-rules.
* TODO: Support directly reading files.

![Screen Shot 2023-05-30 at 11 15 18](https://github.com/statisticsnorway/dapla-toolbelt-pseudo/assets/42948872/ea4520b8-04a6-4539-852a-452754865fad)


See https://github.com/statisticsnorway/dapla-toolbelt-pseudo/blob/builder-ui/tests/builder_examples.ipynb for working examples.

Internal ref: https://statistics-norway.atlassian.net/browse/STAT-527
