### PR TITLE
Add GCS file support

### DIFF
--- a/src/dapla_pseudo/v1/builder.py
+++ b/src/dapla_pseudo/v1/builder.py
@@ -43,11 +43,37 @@ class PseudoData:
 
     @staticmethod
     def from_file(file_path_str: str, **kwargs: Any) -> "_FieldSelector":
-        """Initialize a pseudonymization request from a pandas dataframe read from file."""
+        """Initialize a pseudonymization request from a pandas dataframe read from file.
+
+        Args:
+            file_path_str (str): The path to the file to be read.
+            kwargs (dict): Additional keyword arguments to be passed to the file reader.
+
+        Raises:
+            FileNotFoundError: If no file is found at the specified local path.
+            NoFileExtensionError: If the file has no extension.
+
+        Returns:
+            _FieldSelector: An instance of the _FieldSelector class.
+
+        Examples:
+            # Read from bucket
+            from dapla import AuthClient
+            from dapla_pseudo import PseudoData
+            bucket_path = "gs://ssb-staging-dapla-felles-data-delt/felles/smoke-tests/fruits/data.parquet"
+            storage_options = {"token": AuthClient.fetch_google_credentials()}
+            field_selector = PseudoData.from_file(bucket_path, storage_options=storage_options)
+
+            # Read from local filesystem
+            from dapla_pseudo import PseudoData
+
+            local_path = "some_file.csv"
+            field_selector = PseudoData.from_file(local_path)
+        """
         file_path = Path(file_path_str)
 
-        if not file_path.is_file():
-            raise FileNotFoundError(f"No file found at path: {file_path}")
+        if not file_path.is_file() and "storage_options" not in kwargs:
+            raise FileNotFoundError(f"No local file found in path: {file_path}")
 
         file_extension = file_path.suffix[1:]
 
@@ -57,7 +83,7 @@ class PseudoData:
         file_format = SupportedFileFormat(file_extension)
 
         pandas_function = getattr(pd, file_format.get_pandas_function_name())
-        return PseudoData._FieldSelector(pandas_function(file_path, **kwargs))
+        return PseudoData._FieldSelector(pandas_function(file_path_str, **kwargs))
 
     class _FieldSelector:
         """Select one or multiple fields to be pseudonymized."""

--- a/tests/v1/test_builder.py
+++ b/tests/v1/test_builder.py
@@ -105,6 +105,18 @@ def test_builder_from_file_no_file_extension() -> None:
         PseudoData.from_file(path)
 
 
+@patch(f"{PKG}.pd.read_csv")
+def test_builder_from_file_with_storage_options(pandas_form_csv: Mock) -> None:
+    # This should not raise a FileNotFoundError
+    # since the file is not on the local filesystem
+    try:
+        file_path = "path/to/your/file.csv"
+        storage_options = {"token": "fake_token"}
+        PseudoData.from_file(file_path, storage_options=storage_options)
+    except FileNotFoundError:
+        pytest.fail("FileNotFoundError should not be raised when storage_options is supplied.")
+
+
 @pytest.mark.parametrize(
     "file_format,expected_error",
     [("json", "ValueError"), ("csv", "EmptyDataError"), ("xml", "XMLSyntaxError"), ("parquet", "ArrowInvalid")],


### PR DESCRIPTION
This PR adds support for reading files form GCS buckets.

Example:
```
  from dapla import AuthClient
  from dapla_pseudo import PseudoData
  bucket_path = "gs://ssb-staging-dapla-felles-data-delt/felles/smoke-tests/fruits/data.parquet"
  storage_options = {"token": AuthClient.fetch_google_credentials()}
  field_selector = PseudoData.from_file(bucket_path, storage_options=storage_options)
```

Result of examples test run in jupyter.dapla-staging venv:

<img width="949" alt="Screenshot 2023-06-06 at 15 34 33" src="https://github.com/statisticsnorway/dapla-toolbelt-pseudo/assets/8294494/67f8be15-d6b1-45c0-8a54-9aa97437d23b">
