### PR TITLE
Add configurable timeout

### DIFF
--- a/src/dapla_pseudo/v1/builder.py
+++ b/src/dapla_pseudo/v1/builder.py
@@ -157,6 +157,6 @@ def _do_pseudonymization(
         compression=None,
     )
     response: requests.Response = _client().pseudonymize(
-        pseudonymize_request, _dataframe_to_json(dataframe), stream=True
+        pseudonymize_request, _dataframe_to_json(dataframe), timeout=None, stream=True
     )
     return PseudonymizationResult(dataframe=pd.json_normalize(response.json()))

--- a/src/dapla_pseudo/v1/client.py
+++ b/src/dapla_pseudo/v1/client.py
@@ -40,7 +40,7 @@ class PseudoClient:
         self,
         pseudonymize_request: PseudonymizeFileRequest,
         data: _BinaryFileDecl,
-        timeout: int,
+        timeout: t.Optional[int],
         stream: bool = False,
         name: t.Optional[str] = None,
     ) -> requests.Response:
@@ -100,7 +100,7 @@ class PseudoClient:
         return name
 
     def depseudonymize_file(
-        self, depseudonymize_request: DepseudonymizeFileRequest, file_path: str, timeout: int, stream: bool = False
+        self, depseudonymize_request: DepseudonymizeFileRequest, file_path: str, timeout: t.Optional[int], stream: bool = False
     ) -> requests.Response:
         """Depseudonymize a file (JSON or CSV - or a zip with potentially multiple such files) by uploading the file.
 
@@ -135,7 +135,7 @@ class PseudoClient:
         return self._process_file("depseudonymize", depseudonymize_request, file_path, timeout, stream)
 
     def repseudonymize_file(
-        self, repseudonymize_request: RepseudonymizeFileRequest, file_path: str, timeout: int, stream: bool = False
+        self, repseudonymize_request: RepseudonymizeFileRequest, file_path: str, timeout: t.Optional[int], stream: bool = False
     ) -> requests.Response:
         """Repseudonymize a file (JSON or CSV - or a zip with potentially multiple such files) by uploading the file.
 
@@ -172,7 +172,7 @@ class PseudoClient:
         return self._process_file("repseudonymize", repseudonymize_request, file_path, timeout, stream)
 
     def _process_file(
-        self, operation: str, request: APIModel, file_path: str, timeout: int, stream: bool = False
+        self, operation: str, request: APIModel, file_path: str, timeout: t.Optional[int], stream: bool = False
     ) -> requests.Response:
         file_name = os.path.basename(file_path).split("/")[-1]
         content_type = Mimetypes(mimetypes.MimeTypes().guess_type(file_path)[0])
@@ -189,7 +189,7 @@ class PseudoClient:
         data: t.BinaryIO,
         name: str,
         content_type: Mimetypes,
-        timeout: int,
+        timeout: t.Optional[int],
         stream: bool = False,
     ) -> requests.Response:
         auth_token = self.__auth_token()

--- a/src/dapla_pseudo/v1/client.py
+++ b/src/dapla_pseudo/v1/client.py
@@ -104,7 +104,7 @@ class PseudoClient:
         depseudonymize_request: DepseudonymizeFileRequest,
         file_path: str,
         timeout: t.Optional[int],
-        stream: bool = False
+        stream: bool = False,
     ) -> requests.Response:
         """Depseudonymize a file (JSON or CSV - or a zip with potentially multiple such files) by uploading the file.
 
@@ -143,7 +143,7 @@ class PseudoClient:
         repseudonymize_request: RepseudonymizeFileRequest,
         file_path: str,
         timeout: t.Optional[int],
-        stream: bool = False
+        stream: bool = False,
     ) -> requests.Response:
         """Repseudonymize a file (JSON or CSV - or a zip with potentially multiple such files) by uploading the file.
 

--- a/src/dapla_pseudo/v1/client.py
+++ b/src/dapla_pseudo/v1/client.py
@@ -72,9 +72,15 @@ class PseudoClient:
         :param name: optional name for logging purposes
         :return: pseudonymized data
         """
-        return self._post_to_pseudo_service(self.PSEUDONYMIZE_FILE_ENDPOINT, pseudonymize_request, data,
-                                            self._extract_name(data, pseudonymize_request.target_content_type, name),
-                                            pseudonymize_request.target_content_type, timeout, stream)
+        return self._post_to_pseudo_service(
+            self.PSEUDONYMIZE_FILE_ENDPOINT,
+            pseudonymize_request,
+            data,
+            self._extract_name(data, pseudonymize_request.target_content_type, name),
+            pseudonymize_request.target_content_type,
+            timeout,
+            stream,
+        )
 
     def _extract_name(self, data: t.BinaryIO, content_type: Mimetypes, name: t.Optional[str]) -> str:
         if name is None:
@@ -169,13 +175,19 @@ class PseudoClient:
         content_type = Mimetypes(mimetypes.MimeTypes().guess_type(file_path)[0])
 
         with open(file_path, "rb") as f:
-            return self._post_to_pseudo_service(f"{operation}/file", request, f, file_name, content_type, timeout,
-                                                stream)
+            return self._post_to_pseudo_service(
+                f"{operation}/file", request, f, file_name, content_type, timeout, stream
+            )
 
     def _post_to_pseudo_service(
-        self, path: str, request: APIModel, data: t.BinaryIO, name: str, content_type: Mimetypes, timeout: int,
-            stream: bool = False
-
+            self,
+            path: str,
+            request: APIModel,
+            data: t.BinaryIO,
+            name: str,
+            content_type: Mimetypes,
+            timeout: int,
+            stream: bool = False,
     ) -> requests.Response:
         auth_token = self.__auth_token()
         data_spec: _FileSpecDecl = (name, data, content_type)

--- a/src/dapla_pseudo/v1/client.py
+++ b/src/dapla_pseudo/v1/client.py
@@ -100,7 +100,11 @@ class PseudoClient:
         return name
 
     def depseudonymize_file(
-        self, depseudonymize_request: DepseudonymizeFileRequest, file_path: str, timeout: t.Optional[int], stream: bool = False
+        self,
+        depseudonymize_request: DepseudonymizeFileRequest,
+        file_path: str,
+        timeout: t.Optional[int],
+        stream: bool = False
     ) -> requests.Response:
         """Depseudonymize a file (JSON or CSV - or a zip with potentially multiple such files) by uploading the file.
 
@@ -135,7 +139,11 @@ class PseudoClient:
         return self._process_file("depseudonymize", depseudonymize_request, file_path, timeout, stream)
 
     def repseudonymize_file(
-        self, repseudonymize_request: RepseudonymizeFileRequest, file_path: str, timeout: t.Optional[int], stream: bool = False
+        self,
+        repseudonymize_request: RepseudonymizeFileRequest,
+        file_path: str,
+        timeout: t.Optional[int],
+        stream: bool = False
     ) -> requests.Response:
         """Repseudonymize a file (JSON or CSV - or a zip with potentially multiple such files) by uploading the file.
 

--- a/src/dapla_pseudo/v1/client.py
+++ b/src/dapla_pseudo/v1/client.py
@@ -67,7 +67,7 @@ class PseudoClient:
 
         :param pseudonymize_request: the request to send to Dapla Pseudo Service
         :param data: file handle that should be pseudonymized
-        :param timeout: connection and read, see https://requests.readthedocs.io/en/latest/user/advanced/?highlight=timeout#timeouts
+        :param timeout: connection and read timeout, see https://requests.readthedocs.io/en/latest/user/advanced/?highlight=timeout#timeouts
         :param stream: set to true if the results should be chunked into pieces, e.g. if you operate on large files.
         :param name: optional name for logging purposes
         :return: pseudonymized data

--- a/src/dapla_pseudo/v1/client.py
+++ b/src/dapla_pseudo/v1/client.py
@@ -180,14 +180,14 @@ class PseudoClient:
             )
 
     def _post_to_pseudo_service(
-            self,
-            path: str,
-            request: APIModel,
-            data: t.BinaryIO,
-            name: str,
-            content_type: Mimetypes,
-            timeout: int,
-            stream: bool = False,
+        self,
+        path: str,
+        request: APIModel,
+        data: t.BinaryIO,
+        name: str,
+        content_type: Mimetypes,
+        timeout: int,
+        stream: bool = False,
     ) -> requests.Response:
         auth_token = self.__auth_token()
         data_spec: _FileSpecDecl = (name, data, content_type)

--- a/src/dapla_pseudo/v1/client.py
+++ b/src/dapla_pseudo/v1/client.py
@@ -67,7 +67,8 @@ class PseudoClient:
 
         :param pseudonymize_request: the request to send to Dapla Pseudo Service
         :param data: file handle that should be pseudonymized
-        :param timeout: connection and read timeout, see https://requests.readthedocs.io/en/latest/user/advanced/?highlight=timeout#timeouts
+        :param timeout: connection and read timeout, see
+            https://requests.readthedocs.io/en/latest/user/advanced/?highlight=timeout#timeouts
         :param stream: set to true if the results should be chunked into pieces, e.g. if you operate on large files.
         :param name: optional name for logging purposes
         :return: pseudonymized data
@@ -126,7 +127,8 @@ class PseudoClient:
 
         :param request_json: the request JSON to send to Dapla Pseudo Service
         :param file_path: path to a local file that should be depseudonymized
-        :param timeout: connection and read timeout, see https://requests.readthedocs.io/en/latest/user/advanced/?highlight=timeout#timeouts
+        :param timeout: connection and read timeout, see
+            https://requests.readthedocs.io/en/latest/user/advanced/?highlight=timeout#timeouts
         :param stream: set to true if the results should be chunked into pieces, e.g. if you operate on large files.
         :return: depseudonymized data
         """
@@ -162,7 +164,8 @@ class PseudoClient:
 
         :param request_json: the request JSON to send to Dapla Pseudo Service
         :param file_path: path to a local file that should be depseudonymized
-        :param timeout: connection and read timeout, see https://requests.readthedocs.io/en/latest/user/advanced/?highlight=timeout#timeouts
+        :param timeout: connection and read timeout, see
+            https://requests.readthedocs.io/en/latest/user/advanced/?highlight=timeout#timeouts
         :param stream: set to true if the results should be chunked into pieces, e.g. if you operate on large files.
         :return: repseudonymized data
         """

--- a/src/dapla_pseudo/v1/client.py
+++ b/src/dapla_pseudo/v1/client.py
@@ -40,6 +40,7 @@ class PseudoClient:
         self,
         pseudonymize_request: PseudonymizeFileRequest,
         data: _BinaryFileDecl,
+        timeout: int,
         stream: bool = False,
         name: t.Optional[str] = None,
     ) -> requests.Response:
@@ -66,18 +67,14 @@ class PseudoClient:
 
         :param pseudonymize_request: the request to send to Dapla Pseudo Service
         :param data: file handle that should be pseudonymized
+        :param timeout: connection and read, see https://requests.readthedocs.io/en/latest/user/advanced/?highlight=timeout#timeouts
         :param stream: set to true if the results should be chunked into pieces, e.g. if you operate on large files.
         :param name: optional name for logging purposes
         :return: pseudonymized data
         """
-        return self._post_to_pseudo_service(
-            self.PSEUDONYMIZE_FILE_ENDPOINT,
-            pseudonymize_request,
-            data,
-            self._extract_name(data, pseudonymize_request.target_content_type, name),
-            pseudonymize_request.target_content_type,
-            stream,
-        )
+        return self._post_to_pseudo_service(self.PSEUDONYMIZE_FILE_ENDPOINT, pseudonymize_request, data,
+                                            self._extract_name(data, pseudonymize_request.target_content_type, name),
+                                            pseudonymize_request.target_content_type, timeout, stream)
 
     def _extract_name(self, data: t.BinaryIO, content_type: Mimetypes, name: t.Optional[str]) -> str:
         if name is None:
@@ -96,7 +93,7 @@ class PseudoClient:
         return name
 
     def depseudonymize_file(
-        self, depseudonymize_request: DepseudonymizeFileRequest, file_path: str, stream: bool = False
+        self, depseudonymize_request: DepseudonymizeFileRequest, file_path: str, timeout: int, stream: bool = False
     ) -> requests.Response:
         """Depseudonymize a file (JSON or CSV - or a zip with potentially multiple such files) by uploading the file.
 
@@ -123,13 +120,14 @@ class PseudoClient:
 
         :param request_json: the request JSON to send to Dapla Pseudo Service
         :param file_path: path to a local file that should be depseudonymized
+        :param timeout: connection and read timeout, see https://requests.readthedocs.io/en/latest/user/advanced/?highlight=timeout#timeouts
         :param stream: set to true if the results should be chunked into pieces, e.g. if you operate on large files.
         :return: depseudonymized data
         """
-        return self._process_file("depseudonymize", depseudonymize_request, file_path, stream)
+        return self._process_file("depseudonymize", depseudonymize_request, file_path, timeout, stream)
 
     def repseudonymize_file(
-        self, repseudonymize_request: RepseudonymizeFileRequest, file_path: str, stream: bool = False
+        self, repseudonymize_request: RepseudonymizeFileRequest, file_path: str, timeout: int, stream: bool = False
     ) -> requests.Response:
         """Repseudonymize a file (JSON or CSV - or a zip with potentially multiple such files) by uploading the file.
 
@@ -158,22 +156,26 @@ class PseudoClient:
 
         :param request_json: the request JSON to send to Dapla Pseudo Service
         :param file_path: path to a local file that should be depseudonymized
+        :param timeout: connection and read timeout, see https://requests.readthedocs.io/en/latest/user/advanced/?highlight=timeout#timeouts
         :param stream: set to true if the results should be chunked into pieces, e.g. if you operate on large files.
         :return: repseudonymized data
         """
-        return self._process_file("repseudonymize", repseudonymize_request, file_path, stream)
+        return self._process_file("repseudonymize", repseudonymize_request, file_path, timeout, stream)
 
     def _process_file(
-        self, operation: str, request: APIModel, file_path: str, stream: bool = False
+        self, operation: str, request: APIModel, file_path: str, timeout: int, stream: bool = False
     ) -> requests.Response:
         file_name = os.path.basename(file_path).split("/")[-1]
         content_type = Mimetypes(mimetypes.MimeTypes().guess_type(file_path)[0])
 
         with open(file_path, "rb") as f:
-            return self._post_to_pseudo_service(f"{operation}/file", request, f, file_name, content_type, stream)
+            return self._post_to_pseudo_service(f"{operation}/file", request, f, file_name, content_type, timeout,
+                                                stream)
 
     def _post_to_pseudo_service(
-        self, path: str, request: APIModel, data: t.BinaryIO, name: str, content_type: Mimetypes, stream: bool = False
+        self, path: str, request: APIModel, data: t.BinaryIO, name: str, content_type: Mimetypes, timeout: int,
+            stream: bool = False
+
     ) -> requests.Response:
         auth_token = self.__auth_token()
         data_spec: _FileSpecDecl = (name, data, content_type)
@@ -189,7 +191,7 @@ class PseudoClient:
                 "request": request_spec,
             },
             stream=stream,
-            timeout=30,  # seconds
+            timeout=timeout,
         )
         response.raise_for_status()
         return response

--- a/src/dapla_pseudo/v1/ops.py
+++ b/src/dapla_pseudo/v1/ops.py
@@ -45,7 +45,7 @@ def pseudonymize(
     fields: t.Optional[t.List[_FieldDecl]] = None,
     sid_fields: t.Optional[t.List[str]] = None,
     key: t.Union[str, PseudoKeyset] = PredefinedKeys.SSB_COMMON_KEY_1,
-    timeout: int = 30,
+    timeout: t.Optional[int] = None,
     stream: bool = True,
 ) -> requests.Response:
     """Pseudonymize specified fields of a dataset.
@@ -83,7 +83,8 @@ def pseudonymize(
     :param fields: list of fields that should be pseudonymized
     :param sid_fields: list of fields that should be mapped to stabil ID and pseudonymized
     :param key: either named reference to a "global" key or a keyset json
-    :param timeout: connection and read timeout, see https://requests.readthedocs.io/en/latest/user/advanced/?highlight=timeout#timeouts
+    :param timeout: connection and read timeout, see
+        https://requests.readthedocs.io/en/latest/user/advanced/?highlight=timeout#timeouts
     :param stream: true if the results should be chunked into pieces (use for large data)
     :return: pseudonymized data
     """
@@ -141,7 +142,7 @@ def depseudonymize(
     file_path: str,
     fields: t.List[_FieldDecl],
     key: t.Union[str, PseudoKeyset] = PredefinedKeys.SSB_COMMON_KEY_1,
-    timeout: int = 30,
+    timeout: t.Optional[int] = None,
     stream: bool = True,
 ) -> requests.Response:
     """Depseudonymize specified fields of a local file.
@@ -174,7 +175,8 @@ def depseudonymize(
     :param file_path: path to a local file, e.g. ./path/to/data-deid.json. Supported file formats: csv, json
     :param fields: list of fields that should be depseudonymized
     :param key: either named reference to a "global" key or a keyset json
-    :param timeout: connection and read timeout, see https://requests.readthedocs.io/en/latest/user/advanced/?highlight=timeout#timeouts
+    :param timeout: connection and read timeout, see
+        https://requests.readthedocs.io/en/latest/user/advanced/?highlight=timeout#timeouts
     :param stream: true if the results should be chunked into pieces (use for large data)
     :return: depseudonymized data
     """
@@ -196,7 +198,7 @@ def repseudonymize(
     fields: t.List[_FieldDecl],
     source_key: t.Union[str, PseudoKeyset] = PredefinedKeys.SSB_COMMON_KEY_1,
     target_key: t.Union[str, PseudoKeyset] = PredefinedKeys.SSB_COMMON_KEY_1,
-    timeout: int = 30,
+    timeout: t.Optional[int] = None,
     stream: bool = True,
 ) -> requests.Response:
     """Repseudonymize specified fields of a local, previously pseudonymized file.
@@ -230,7 +232,8 @@ def repseudonymize(
     :param fields: list of fields that should be pseudonymized
     :param source_key: either named reference to a "global" key or a keyset json - used for depseudonymization
     :param target_key: either named reference to a "global" key or a keyset json - used for pseudonymization
-    :param timeout: connection and read timeout, see https://requests.readthedocs.io/en/latest/user/advanced/?highlight=timeout#timeouts
+    :param timeout: connection and read timeout, see
+        https://requests.readthedocs.io/en/latest/user/advanced/?highlight=timeout#timeouts
     :param stream: true if the results should be chunked into pieces (use for large data)
     :return: repseudonymized data
     """

--- a/src/dapla_pseudo/v1/ops.py
+++ b/src/dapla_pseudo/v1/ops.py
@@ -45,6 +45,7 @@ def pseudonymize(
     fields: t.Optional[t.List[_FieldDecl]] = None,
     sid_fields: t.Optional[t.List[str]] = None,
     key: t.Union[str, PseudoKeyset] = PredefinedKeys.SSB_COMMON_KEY_1,
+    timeout: int = None,
     stream: bool = True,
 ) -> requests.Response:
     """Pseudonymize specified fields of a dataset.
@@ -82,6 +83,7 @@ def pseudonymize(
     :param fields: list of fields that should be pseudonymized
     :param sid_fields: list of fields that should be mapped to stabil ID and pseudonymized
     :param key: either named reference to a "global" key or a keyset json
+    :param timeout: connection and read timeout, see https://requests.readthedocs.io/en/latest/user/advanced/?highlight=timeout#timeouts
     :param stream: true if the results should be chunked into pieces (use for large data)
     :return: pseudonymized data
     """
@@ -128,15 +130,17 @@ def pseudonymize(
     )
 
     if file_handle is not None:
-        return _client().pseudonymize(pseudonymize_request, file_handle, stream=stream, name=name)
+        return _client().pseudonymize(pseudonymize_request, file_handle, stream=stream, name=name, timeout=timeout)
     else:
-        return _client()._process_file("pseudonymize", pseudonymize_request, str(dataset), stream=stream)
+        return _client()._process_file("pseudonymize", pseudonymize_request, str(dataset), stream=stream,
+                                       timeout=timeout)
 
 
 def depseudonymize(
     file_path: str,
     fields: t.List[_FieldDecl],
     key: t.Union[str, PseudoKeyset] = PredefinedKeys.SSB_COMMON_KEY_1,
+    timeout: int = None,
     stream: bool = True,
 ) -> requests.Response:
     """Depseudonymize specified fields of a local file.
@@ -169,6 +173,7 @@ def depseudonymize(
     :param file_path: path to a local file, e.g. ./path/to/data-deid.json. Supported file formats: csv, json
     :param fields: list of fields that should be depseudonymized
     :param key: either named reference to a "global" key or a keyset json
+    :param timeout: connection and read timeout, see https://requests.readthedocs.io/en/latest/user/advanced/?highlight=timeout#timeouts
     :param stream: true if the results should be chunked into pieces (use for large data)
     :return: depseudonymized data
     """
@@ -182,7 +187,7 @@ def depseudonymize(
         compression=None,
     )
 
-    return _client().depseudonymize_file(req, file_path, stream=stream)
+    return _client().depseudonymize_file(req, file_path, stream=stream, timeout=timeout)
 
 
 def repseudonymize(
@@ -190,6 +195,7 @@ def repseudonymize(
     fields: t.List[_FieldDecl],
     source_key: t.Union[str, PseudoKeyset] = PredefinedKeys.SSB_COMMON_KEY_1,
     target_key: t.Union[str, PseudoKeyset] = PredefinedKeys.SSB_COMMON_KEY_1,
+    timeout: int = None,
     stream: bool = True,
 ) -> requests.Response:
     """Repseudonymize specified fields of a local, previously pseudonymized file.
@@ -223,6 +229,7 @@ def repseudonymize(
     :param fields: list of fields that should be pseudonymized
     :param source_key: either named reference to a "global" key or a keyset json - used for depseudonymization
     :param target_key: either named reference to a "global" key or a keyset json - used for pseudonymization
+    :param timeout: connection and read timeout, see https://requests.readthedocs.io/en/latest/user/advanced/?highlight=timeout#timeouts
     :param stream: true if the results should be chunked into pieces (use for large data)
     :return: repseudonymized data
     """
@@ -239,7 +246,7 @@ def repseudonymize(
         compression=None,
     )
 
-    return _client().repseudonymize_file(req, file_path, stream=stream)
+    return _client().repseudonymize_file(req, file_path, stream=stream, timeout=timeout)
 
 
 def _client() -> PseudoClient:

--- a/src/dapla_pseudo/v1/ops.py
+++ b/src/dapla_pseudo/v1/ops.py
@@ -132,8 +132,9 @@ def pseudonymize(
     if file_handle is not None:
         return _client().pseudonymize(pseudonymize_request, file_handle, stream=stream, name=name, timeout=timeout)
     else:
-        return _client()._process_file("pseudonymize", pseudonymize_request, str(dataset), stream=stream,
-                                       timeout=timeout)
+        return _client()._process_file(
+            "pseudonymize", pseudonymize_request, str(dataset), stream=stream, timeout=timeout
+        )
 
 
 def depseudonymize(

--- a/src/dapla_pseudo/v1/ops.py
+++ b/src/dapla_pseudo/v1/ops.py
@@ -45,7 +45,7 @@ def pseudonymize(
     fields: t.Optional[t.List[_FieldDecl]] = None,
     sid_fields: t.Optional[t.List[str]] = None,
     key: t.Union[str, PseudoKeyset] = PredefinedKeys.SSB_COMMON_KEY_1,
-    timeout: int = None,
+    timeout: int = 30,
     stream: bool = True,
 ) -> requests.Response:
     """Pseudonymize specified fields of a dataset.
@@ -141,7 +141,7 @@ def depseudonymize(
     file_path: str,
     fields: t.List[_FieldDecl],
     key: t.Union[str, PseudoKeyset] = PredefinedKeys.SSB_COMMON_KEY_1,
-    timeout: int = None,
+    timeout: int = 30,
     stream: bool = True,
 ) -> requests.Response:
     """Depseudonymize specified fields of a local file.
@@ -196,7 +196,7 @@ def repseudonymize(
     fields: t.List[_FieldDecl],
     source_key: t.Union[str, PseudoKeyset] = PredefinedKeys.SSB_COMMON_KEY_1,
     target_key: t.Union[str, PseudoKeyset] = PredefinedKeys.SSB_COMMON_KEY_1,
-    timeout: int = None,
+    timeout: int = 30,
     stream: bool = True,
 ) -> requests.Response:
     """Repseudonymize specified fields of a local, previously pseudonymized file.


### PR DESCRIPTION
The timeout was hard-coded to 30 secs, which according to the [spec](https://requests.readthedocs.io/en/latest/user/advanced/?highlight=timeout#timeouts) will be applied to both the `connect` and the `read` timeouts. 

This PR will make this timeout configurable, so that end users can decide these values.