### PR TITLE
Update outdated builder example notebook

### DIFF
--- a/tests/builder_examples.ipynb
+++ b/tests/builder_examples.ipynb
@@ -51,7 +51,7 @@
     "result = (\n",
     "    PseudoData.from_pandas(df).on_field(\"fnr\").pseudonymize()\n",
     ")\n",
-    "result.dataframe.head()"
+    "result.to_polars().head()"
    ]
   },
   {
@@ -77,7 +77,7 @@
     "    .map_to_stable_id()\n",
     "    .pseudonymize()\n",
     ")\n",
-    "result.dataframe.head()"
+    "result.to_polars().head()"
    ]
   },
   {
@@ -102,7 +102,7 @@
     "    .on_field(\"fnr\")\n",
     "    .pseudonymize(preserve_formatting=True)\n",
     ")\n",
-    "result.dataframe.head()"
+    "result.to_polars().head()"
    ]
   },
   {
@@ -127,7 +127,7 @@
     "    .on_fields(\"fornavn\", \"etternavn\", \"fodselsdato\")\n",
     "    .pseudonymize()\n",
     ")\n",
-    "result.dataframe.head()"
+    "result.to_polars().head()"
    ]
   },
   {
@@ -155,31 +155,23 @@
     "    .pseudonymize()\n",
     ")\n",
     "result = (\n",
-    "    PseudoData.from_pandas(result.dataframe)\n",
+    "    PseudoData.from_pandas(result.to_polars())\n",
     "    .on_fields(\"fornavn\", \"etternavn\", \"fodselsdato\")\n",
     "    .pseudonymize()\n",
     ")\n",
-    "result.dataframe.head()"
+    "result.to_polars().head()"
    ]
   }
  ],
  "metadata": {
-  "kernelspec": {
-   "display_name": "dapla-toolbelt-pseudo-s0-eGPKC-py3.10",
-   "language": "python",
-   "name": "python3"
-  },
   "language_info": {
    "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
+    "name": "ipython"
    },
    "file_extension": ".py",
    "mimetype": "text/x-python",
    "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.10.10"
+   "nbconvert_exporter": "python"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Replace `.dataframe` with `.to_polars()` when accessing the `PseudonymizationResult` in the builder example notebook. This change ensures compatibility with the latest version of dapla_pseudo.

The current version of dapla_pseudo offers two ways to access the DataFrame of a `PseudonymizationResult` either `to_polars()` or `to_pandas()`.