### PR TITLE
Read files with polars

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -85,6 +85,15 @@ $ nox --session=tests
 Unit tests are located in the _tests_ directory,
 and are written using the [pytest] testing framework.
 
+### Local Testing
+
+When testing against a local instance of [dapla-pseudo-service](https://github.com/statisticsnorway/dapla-dlp-pseudo-service), you can configure the URL and authentication token by providing the following environment variables:
+
+```console
+PSEUDO_SERVICE_URL=http://localhost:<PORT>
+PSEUDO_SERVICE_AUTH_TOKEN=<KEYCLOAK_TOKEN>
+```
+
 [pytest]: https://pytest.readthedocs.io/
 
 ## How to submit changes

--- a/src/dapla_pseudo/v1/builder.py
+++ b/src/dapla_pseudo/v1/builder.py
@@ -18,6 +18,7 @@ from dapla_pseudo.v1.models import PseudoKeyset
 from dapla_pseudo.v1.ops import _client
 from dapla_pseudo.v1.supported_file_format import NoFileExtensionError
 from dapla_pseudo.v1.supported_file_format import SupportedFileFormat
+from dapla_pseudo.v1.supported_file_format import read_to_df
 
 
 class PseudonymizationResult:
@@ -104,7 +105,7 @@ class PseudoData:
 
         file_format = SupportedFileFormat(file_extension)
 
-        return PseudoData._FieldSelector(file_format.read_to_df(file_path_str, **kwargs))
+        return PseudoData._FieldSelector(read_to_df(file_format, file_path_str, **kwargs))
 
     class _FieldSelector:
         """Select one or multiple fields to be pseudonymized."""

--- a/src/dapla_pseudo/v1/builder.py
+++ b/src/dapla_pseudo/v1/builder.py
@@ -104,8 +104,7 @@ class PseudoData:
 
         file_format = SupportedFileFormat(file_extension)
 
-        pandas_function = getattr(pd, file_format.get_pandas_function_name())
-        return PseudoData._FieldSelector(pandas_function(file_path_str, **kwargs))
+        return PseudoData._FieldSelector(file_format.read_to_df(file_path_str, **kwargs))
 
     class _FieldSelector:
         """Select one or multiple fields to be pseudonymized."""

--- a/src/dapla_pseudo/v1/supported_file_format.py
+++ b/src/dapla_pseudo/v1/supported_file_format.py
@@ -22,7 +22,7 @@ class SupportedFileFormat(Enum):
 
     def read_to_df(self, file_path: str, **kwargs: Dict[str, Any]) -> Union[pl.DataFrame, pd.DataFrame]:
         """Reads a file with a supported file format to a Dataframe."""
-        polars_supported_formats = [self.PARQUET.value]
+        polars_supported_formats = [SupportedFileFormat.PARQUET.value]
         function_name = self.get_function_name()
 
         if self.value in polars_supported_formats:

--- a/src/dapla_pseudo/v1/supported_file_format.py
+++ b/src/dapla_pseudo/v1/supported_file_format.py
@@ -16,22 +16,21 @@ class SupportedFileFormat(Enum):
     XML = "xml"
     PARQUET = "parquet"
 
-    def get_function_name(self) -> str:
-        """Returns the reader function name for the file format."""
-        return f"read_{self.value}"
 
-    def read_to_df(self, file_path: str, **kwargs: Dict[str, Any]) -> Union[pl.DataFrame, pd.DataFrame]:
-        """Reads a file with a supported file format to a Dataframe."""
-        polars_supported_formats = [SupportedFileFormat.PARQUET.value]
-        function_name = self.get_function_name()
+FORMAT_TO_READER_FUNCTION = {
+    SupportedFileFormat.CSV: pd.read_csv,
+    SupportedFileFormat.JSON: pd.read_json,
+    SupportedFileFormat.XML: pd.read_xml,
+    SupportedFileFormat.PARQUET: pl.read_parquet,
+}
 
-        if self.value in polars_supported_formats:
-            reader_function = getattr(pl, function_name)
 
-        else:
-            reader_function = getattr(pd, function_name)
-
-        return reader_function(file_path, **kwargs)
+def read_to_df(
+    supported_format: SupportedFileFormat, file_path: str, **kwargs: Dict[str, Any]
+) -> Union[pl.DataFrame, pd.DataFrame]:
+    """Reads a file with a supported file format to a Dataframe."""
+    reader_function = FORMAT_TO_READER_FUNCTION[supported_format]
+    return reader_function(file_path, **kwargs)
 
 
 class NoFileExtensionError(Exception):

--- a/src/dapla_pseudo/v1/supported_file_format.py
+++ b/src/dapla_pseudo/v1/supported_file_format.py
@@ -1,5 +1,11 @@
 """Classes used to support reading of dataframes from file."""
 from enum import Enum
+from typing import Any
+from typing import Dict
+from typing import Union
+
+import pandas as pd
+import polars as pl
 
 
 class SupportedFileFormat(Enum):
@@ -10,9 +16,21 @@ class SupportedFileFormat(Enum):
     XML = "xml"
     PARQUET = "parquet"
 
-    def get_pandas_function_name(self) -> str:
-        """Return the pandas function name for the file format."""
+    def get_function_name(self) -> str:
+        """Returns the reader function name for the file format."""
         return f"read_{self.value}"
+
+    def read_to_df(self, file_path: str, **kwargs: Dict[str, Any]) -> Union[pl.DataFrame, pd.DataFrame]:
+        """Reads a file with a supported file format to a Dataframe."""
+        polars_supported_formats = [self.CSV, self.PARQUET]
+        function_name = self.get_function_name()
+
+        if self.value in polars_supported_formats:
+            reader_function = getattr(pl, function_name)
+        else:
+            reader_function = getattr(pd, function_name)
+
+        return reader_function(file_path, **kwargs)
 
 
 class NoFileExtensionError(Exception):

--- a/src/dapla_pseudo/v1/supported_file_format.py
+++ b/src/dapla_pseudo/v1/supported_file_format.py
@@ -22,11 +22,12 @@ class SupportedFileFormat(Enum):
 
     def read_to_df(self, file_path: str, **kwargs: Dict[str, Any]) -> Union[pl.DataFrame, pd.DataFrame]:
         """Reads a file with a supported file format to a Dataframe."""
-        polars_supported_formats = [self.CSV, self.PARQUET]
+        polars_supported_formats = [self.PARQUET.value]
         function_name = self.get_function_name()
 
         if self.value in polars_supported_formats:
             reader_function = getattr(pl, function_name)
+
         else:
             reader_function = getattr(pd, function_name)
 

--- a/tests/v1/test_builder.py
+++ b/tests/v1/test_builder.py
@@ -225,7 +225,7 @@ def test_builder_from_file_with_storage_options(pandas_form_csv: Mock) -> None:
 
 @pytest.mark.parametrize(
     "file_format,expected_error",
-    [("json", "ValueError"), ("csv", "EmptyDataError"), ("xml", "XMLSyntaxError"), ("parquet", "ArrowInvalid")],
+    [("json", "ValueError"), ("csv", "EmptyDataError"), ("xml", "XMLSyntaxError"), ("parquet", "ArrowErrorException")],
 )
 @patch("pathlib.Path.suffix")
 def test_builder_from_file_empty_file(mock_path_suffix: Mock, file_format: str, expected_error: str) -> None:

--- a/tests/v1/test_builder.py
+++ b/tests/v1/test_builder.py
@@ -211,8 +211,8 @@ def test_builder_from_file_no_file_extension() -> None:
         PseudoData.from_file(path)
 
 
-@patch(f"{PKG}.pd.read_csv")
-def test_builder_from_file_with_storage_options(pandas_form_csv: Mock) -> None:
+@patch(f"{PKG}.read_to_df")
+def test_builder_from_file_with_storage_options(_mock_read_to_df: Mock) -> None:
     # This should not raise a FileNotFoundError
     # since the file is not on the local filesystem
     try:

--- a/tests/v1/test_supported_file_format.py
+++ b/tests/v1/test_supported_file_format.py
@@ -1,19 +1,12 @@
-import pandas as pd
 import polars as pl
 import pytest
 
 from dapla_pseudo.v1.supported_file_format import SupportedFileFormat
+from dapla_pseudo.v1.supported_file_format import read_to_df
 
 
 PKG = "dapla_pseudo.v1.supported_file_format"
 TEST_FILE_PATH = "tests/v1/test_files"
-
-
-@pytest.mark.parametrize("file_format", ["json", "csv", "xml", "parquet"])
-def test_get_pandas_function_name(file_format: str) -> None:
-    # Checks that a pandas function exists for all supported file formats.
-    supported_file_format = SupportedFileFormat(file_format)
-    assert getattr(pd, supported_file_format.get_function_name())
 
 
 def test_get_pandas_function_name_unsupported_format() -> None:
@@ -34,5 +27,5 @@ def test_get_pandas_function_name_unsupported_format() -> None:
 )
 def test_supported_files_read_with_polars(file_format: str, read_with_polars: bool) -> None:
     supported_file_format = SupportedFileFormat(file_format)
-    df = supported_file_format.read_to_df(f"{TEST_FILE_PATH}/test.{file_format}")
+    df = read_to_df(supported_file_format, f"{TEST_FILE_PATH}/test.{file_format}")
     assert isinstance(df, pl.DataFrame) is read_with_polars

--- a/tests/v1/test_supported_file_format.py
+++ b/tests/v1/test_supported_file_format.py
@@ -11,7 +11,7 @@ PKG = "dapla_pseudo.v1.supported_file_format"
 def test_get_pandas_function_name(file_format: str) -> None:
     # Checks that a pandas function exists for all supported file formats.
     supported_file_format = SupportedFileFormat(file_format)
-    assert getattr(pd, supported_file_format.get_pandas_function_name())
+    assert getattr(pd, supported_file_format.get_function_name())
 
 
 def test_get_pandas_function_name_unsupported_format() -> None:

--- a/tests/v1/test_supported_file_format.py
+++ b/tests/v1/test_supported_file_format.py
@@ -1,10 +1,12 @@
 import pandas as pd
+import polars as pl
 import pytest
 
 from dapla_pseudo.v1.supported_file_format import SupportedFileFormat
 
 
 PKG = "dapla_pseudo.v1.supported_file_format"
+TEST_FILE_PATH = "tests/v1/test_files"
 
 
 @pytest.mark.parametrize("file_format", ["json", "csv", "xml", "parquet"])
@@ -19,3 +21,18 @@ def test_get_pandas_function_name_unsupported_format() -> None:
     unsupported_format = "notsupported"
     with pytest.raises(ValueError):
         SupportedFileFormat(unsupported_format)
+
+
+@pytest.mark.parametrize(
+    "file_format, read_with_polars",
+    [
+        ("json", False),
+        ("csv", False),
+        ("xml", False),
+        ("parquet", True),
+    ],
+)
+def test_supported_files_read_with_polars(file_format: str, read_with_polars: bool) -> None:
+    supported_file_format = SupportedFileFormat(file_format)
+    df = supported_file_format.read_to_df(f"{TEST_FILE_PATH}/test.{file_format}")
+    assert isinstance(df, pl.DataFrame) is read_with_polars


### PR DESCRIPTION
## Changes
The `PseudoData.from_file` function will now use polars when reading `parquet` formatted files. This should improve performance when reading `parquet`.

This resolves [issue#227](https://github.com/statisticsnorway/dapla-toolbelt-pseudo/issues/227)

### Reason for not using polars for 'csv' files
I have opted not to use Polars for reading CSV files because it would necessitate us to handle a convertion between Polars 'dtypes' and Pandas 'dtype'.

Currently, all the file formats we support reading can either have data types specified with the `dtype` keyword argument or derive the schema from the file. We should avoid requiring users to define data types differently for CSV files. 
### dtypes vs dtype
Pandas.[read_csv](https://pandas.pydata.org/docs/reference/api/pandas.read_csv.html) dtypes:`dtype or dict of {Hashabledtype}`
Polars.[read_csv](https://pola-rs.github.io/polars/py-polars/html/reference/api/polars.read_csv.html) dtype: `Mapping[str, PolarsDataType] | Sequence[PolarsDataType] | None = None`

## QOL changes:
- [Add example of how to ovveride service url and token](https://github.com/statisticsnorway/dapla-toolbelt-pseudo/pull/244/commits/73a484116fe8e872c9ad129156489d157340af91)