### PR TITLE
Fix unhashable type exception

### DIFF
--- a/src/dapla_pseudo/v1/ops.py
+++ b/src/dapla_pseudo/v1/ops.py
@@ -315,8 +315,9 @@ def _dataframe_to_json(
     sid_fields: t.Optional[t.Sequence[str]] = None,
 ) -> t.BinaryIO:
     # Ensure fields to be pseudonymized are string type
-    for field in set(fields or []).union(sid_fields or []):
-        data[field] = data[field].apply(str)
+    for field in tuple(fields or []) + tuple(sid_fields or []):
+        if isinstance(field, str):
+            data[field] = data[field].apply(str)
 
     file_handle = io.BytesIO()
     data.to_json(file_handle, orient="records")

--- a/tests/v1/test_pseudonymize.py
+++ b/tests/v1/test_pseudonymize.py
@@ -260,7 +260,7 @@ def test_pseudonymize_request_with_sid(
     monkeypatch.setenv(Env.PSEUDO_SERVICE_AUTH_TOKEN, auth_token)
 
     pseudonymize(
-        test_data_json_file_path,
+        pd.read_json(test_data_json_file_path),
         fields=[Field(pattern="**/fnr", mapping="sid"), {"pattern": "**/fnr2", "mapping": "sid"}, "fornavn"],
     )
     patched_post.assert_called_once()


### PR DESCRIPTION
Using anything else than `str` as an argument in `fields` or `sid_fields` resulted in this error when creating a set:
`TypeError: unhashable type: 'dict'` or `TypeError: unhashable type: 'Field'`

Use tuples instead since they are immutable. Also check the field type before applying string type to the dataframe.

