### PR TITLE
Changed upper bound of Python version to match SciPy

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ packages = [{ include = "dapla_pseudo", from = "src" }]
 Changelog = "https://github.com/statisticsnorway/dapla-toolbelt-pseudo/releases"
 
 [tool.poetry.dependencies]
-python = ">=3.10, <3.13"
+python = ">=3.10, <3.12" # This needs to be pinned in sync with SciPy.
 pydantic = ">=2.0"
 pyhumps = ">=3.8.0"
 types-requests = ">=2.28.11"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ packages = [{ include = "dapla_pseudo", from = "src" }]
 Changelog = "https://github.com/statisticsnorway/dapla-toolbelt-pseudo/releases"
 
 [tool.poetry.dependencies]
-python = ">=3.10, <=3.12"
+python = ">=3.10, <3.13"
 pydantic = ">=2.0"
 pyhumps = ">=3.8.0"
 types-requests = ">=2.28.11"


### PR DESCRIPTION
This is in order to stop having to fiddle with pyproject.toml when importing Pandas
