### PR TITLE
Authenticate with Pseudo Service useing google credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ options = {
     # Specify data types of columns in the dataset
     "dtype" : { "fnr": "string","fornavn": "string","etternavn": "string","kjonn": "category","fodselsdato": "string"},
     # Specify storage options for Google Cloud Storage (GCS)
-    "storage_options" : {"token": AuthClient.fetch_google_token()}
+    "storage_options" : {"token": AuthClient.fetch_google_credentials()}
 }
 
 gcs_file_path = "gs://ssb-staging-dapla-felles-data-delt/felles/pseudo-examples/andeby_personer.csv"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dapla-toolbelt-pseudo"
-version = "0.5.5"
+version = "0.5.6"
 description = "Pseudonymization extensions for Dapla Toolbelt"
 authors = ["Team Skyinfrastruktur <dapla@ssb.no>"]
 license = "MIT"

--- a/src/dapla_pseudo/v1/client.py
+++ b/src/dapla_pseudo/v1/client.py
@@ -36,7 +36,11 @@ class PseudoClient:
         self.static_auth_token = auth_token
 
     def __auth_token(self) -> str:
-        return str(AuthClient.fetch_personal_token()) if self.static_auth_token is None else str(self.static_auth_token)
+        return (
+            str(AuthClient.fetch_google_credentials())
+            if self.static_auth_token is None
+            else str(self.static_auth_token)
+        )
 
     def pseudonymize_file(
         self,

--- a/tests/v1/test_pseudonymize.py
+++ b/tests/v1/test_pseudonymize.py
@@ -49,15 +49,14 @@ def test_data_csv_file_path(test_data_json_file_path: str) -> str:
     return test_data_json_file_path.replace(".json", ".csv")
 
 
-@mock.patch("dapla.auth.AuthClient")
+@mock.patch("dapla.auth.AuthClient.fetch_google_credentials")
 @mock.patch(REQUESTS_POST)
 def test_pseudonymize_with_default_env_values(
-    patched_post: mock.Mock, patched_auth_client: mock.Mock, test_data_json_file_path: str
+    patched_post: mock.Mock, patched_fetch_google_credentials: mock.Mock, test_data_json_file_path: str
 ) -> None:
-    patched_auth_client.fetch_local_user.return_value = {"access_token": auth_token}
-
+    patched_fetch_google_credentials.return_value = auth_token
     pseudonymize(test_data_json_file_path, fields=["fnr", "fornavn"])
-    patched_auth_client.called_once()
+    patched_fetch_google_credentials.called_once()
     patched_post.assert_called_once()
     arg = patched_post.call_args.kwargs
 
@@ -65,12 +64,12 @@ def test_pseudonymize_with_default_env_values(
     assert arg["headers"]["Authorization"] == f"Bearer {auth_token}"
 
 
-@mock.patch("dapla.auth.AuthClient")
+@mock.patch("dapla.auth.AuthClient.fetch_google_credentials")
 @mock.patch(REQUESTS_POST)
 def test_pseudonymize_dataframe(
-    patched_post: mock.Mock, patched_auth_client: mock.Mock, test_data_json_file_path: str
+    patched_post: mock.Mock, patched_fetch_google_credentials: mock.Mock, test_data_json_file_path: str
 ) -> None:
-    patched_auth_client.fetch_local_user.return_value = {"access_token": auth_token}
+    patched_fetch_google_credentials.return_value = {"access_token": auth_token}
     df = pd.read_json(test_data_json_file_path)
 
     pseudonymize(df, fields=["fnr", "fornavn"])
@@ -82,12 +81,12 @@ def test_pseudonymize_dataframe(
     assert arg["files"]["data"][2] == Mimetypes.JSON
 
 
-@mock.patch("dapla.auth.AuthClient")
+@mock.patch("dapla.auth.AuthClient.fetch_google_credentials")
 @mock.patch(REQUESTS_POST)
 def test_pseudonymize_csv_file(
-    patched_post: mock.Mock, patched_auth_client: mock.Mock, test_data_csv_file_path: str
+    patched_post: mock.Mock, patched_fetch_google_credentials: mock.Mock, test_data_csv_file_path: str
 ) -> None:
-    patched_auth_client.fetch_local_user.return_value = {"access_token": auth_token}
+    patched_fetch_google_credentials.return_value = {"access_token": auth_token}
 
     pseudonymize(test_data_csv_file_path, fields=["fnr", "fornavn"])
     patched_post.assert_called_once()
@@ -98,12 +97,12 @@ def test_pseudonymize_csv_file(
     assert arg["files"]["data"][2] == Mimetypes.CSV
 
 
-@mock.patch("dapla.auth.AuthClient")
+@mock.patch("dapla.auth.AuthClient.fetch_google_credentials")
 @mock.patch(REQUESTS_POST)
 def test_pseudonymize_file_handle(
-    patched_post: mock.Mock, patched_auth_client: mock.Mock, test_data_json_file_path: str
+    patched_post: mock.Mock, patched_fetch_google_credentials: mock.Mock, test_data_json_file_path: str
 ) -> None:
-    patched_auth_client.fetch_local_user.return_value = {"access_token": auth_token}
+    patched_fetch_google_credentials.return_value = {"access_token": auth_token}
     with open(test_data_json_file_path, "rb") as data:
         pseudonymize(data, fields=["fnr", "fornavn"])
     patched_post.assert_called_once()
@@ -114,12 +113,12 @@ def test_pseudonymize_file_handle(
     assert arg["files"]["data"][2] == Mimetypes.JSON
 
 
-@mock.patch("dapla.auth.AuthClient")
+@mock.patch("dapla.auth.AuthClient.fetch_google_credentials")
 @mock.patch(REQUESTS_POST)
 def test_pseudonymize_fsspec_file(
-    patched_post: mock.Mock, patched_auth_client: mock.Mock, test_data_json_file_path: str
+    patched_post: mock.Mock, patched_fetch_google_credentials: mock.Mock, test_data_json_file_path: str
 ) -> None:
-    patched_auth_client.fetch_local_user.return_value = {"access_token": auth_token}
+    patched_fetch_google_credentials.return_value = {"access_token": auth_token}
     fs = GCSFileSystem()
     with fs.open("gs://anaconda-public-data/iris/iris.csv", "rb") as data:
         pseudonymize(data, fields=["fnr", "fornavn"])
@@ -131,9 +130,9 @@ def test_pseudonymize_fsspec_file(
     assert arg["files"]["data"][2] == Mimetypes.CSV
 
 
-@mock.patch("dapla.auth.AuthClient")
-def test_pseudonymize_invalid_type(patched_auth_client: mock.Mock, test_data_json_file_path: str) -> None:
-    patched_auth_client.fetch_local_user.return_value = {"access_token": auth_token}
+@mock.patch("dapla.auth.AuthClient.fetch_google_credentials")
+def test_pseudonymize_invalid_type(patched_fetch_google_credentials: mock.Mock, test_data_json_file_path: str) -> None:
+    patched_fetch_google_credentials.return_value = {"access_token": auth_token}
 
     with open(test_data_json_file_path) as data:
         with suppress_type_checks():


### PR DESCRIPTION
After the service was moved to k8s we use google credentials instead of a keycloak access token to authenticate with the Pseudo Service.

### Changes:
- Use google credentials instead of keycloak access token
- Update readme example('fetch_google_token'  relies on 'fetch_local_user', this means it only works from jupyter)
- Bump version
- Update tests