### PR TITLE
Revert #273 go back to using keycloak token

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ options = {
     # Specify data types of columns in the dataset
     "dtype" : { "fnr": "string","fornavn": "string","etternavn": "string","kjonn": "category","fodselsdato": "string"},
     # Specify storage options for Google Cloud Storage (GCS)
-    "storage_options" : {"token": AuthClient.fetch_google_token()}
+    "storage_options" : {"token": AuthClient.fetch_google_credentials()}
 }
 
 gcs_file_path = "gs://ssb-staging-dapla-felles-data-delt/felles/pseudo-examples/andeby_personer.csv"

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ options = {
     # Specify data types of columns in the dataset
     "dtype" : { "fnr": "string","fornavn": "string","etternavn": "string","kjonn": "category","fodselsdato": "string"},
     # Specify storage options for Google Cloud Storage (GCS)
-    "storage_options" : {"token": AuthClient.fetch_google_credentials()}
+    "storage_options" : {"token": AuthClient.fetch_google_token()}
 }
 
 gcs_file_path = "gs://ssb-staging-dapla-felles-data-delt/felles/pseudo-examples/andeby_personer.csv"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dapla-toolbelt-pseudo"
-version = "0.5.6"
+version = "0.5.5"
 description = "Pseudonymization extensions for Dapla Toolbelt"
 authors = ["Team Skyinfrastruktur <dapla@ssb.no>"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dapla-toolbelt-pseudo"
-version = "0.5.5"
+version = "0.5.7"
 description = "Pseudonymization extensions for Dapla Toolbelt"
 authors = ["Team Skyinfrastruktur <dapla@ssb.no>"]
 license = "MIT"

--- a/src/dapla_pseudo/v1/client.py
+++ b/src/dapla_pseudo/v1/client.py
@@ -36,11 +36,7 @@ class PseudoClient:
         self.static_auth_token = auth_token
 
     def __auth_token(self) -> str:
-        return (
-            str(AuthClient.fetch_google_credentials())
-            if self.static_auth_token is None
-            else str(self.static_auth_token)
-        )
+        return str(AuthClient.fetch_personal_token()) if self.static_auth_token is None else str(self.static_auth_token)
 
     def pseudonymize_file(
         self,

--- a/tests/v1/test_pseudonymize.py
+++ b/tests/v1/test_pseudonymize.py
@@ -49,14 +49,15 @@ def test_data_csv_file_path(test_data_json_file_path: str) -> str:
     return test_data_json_file_path.replace(".json", ".csv")
 
 
-@mock.patch("dapla.auth.AuthClient.fetch_google_credentials")
+@mock.patch("dapla.auth.AuthClient")
 @mock.patch(REQUESTS_POST)
 def test_pseudonymize_with_default_env_values(
-    patched_post: mock.Mock, patched_fetch_google_credentials: mock.Mock, test_data_json_file_path: str
+    patched_post: mock.Mock, patched_auth_client: mock.Mock, test_data_json_file_path: str
 ) -> None:
-    patched_fetch_google_credentials.return_value = auth_token
+    patched_auth_client.fetch_local_user.return_value = {"access_token": auth_token}
+
     pseudonymize(test_data_json_file_path, fields=["fnr", "fornavn"])
-    patched_fetch_google_credentials.called_once()
+    patched_auth_client.called_once()
     patched_post.assert_called_once()
     arg = patched_post.call_args.kwargs
 
@@ -64,12 +65,12 @@ def test_pseudonymize_with_default_env_values(
     assert arg["headers"]["Authorization"] == f"Bearer {auth_token}"
 
 
-@mock.patch("dapla.auth.AuthClient.fetch_google_credentials")
+@mock.patch("dapla.auth.AuthClient")
 @mock.patch(REQUESTS_POST)
 def test_pseudonymize_dataframe(
-    patched_post: mock.Mock, patched_fetch_google_credentials: mock.Mock, test_data_json_file_path: str
+    patched_post: mock.Mock, patched_auth_client: mock.Mock, test_data_json_file_path: str
 ) -> None:
-    patched_fetch_google_credentials.return_value = {"access_token": auth_token}
+    patched_auth_client.fetch_local_user.return_value = {"access_token": auth_token}
     df = pd.read_json(test_data_json_file_path)
 
     pseudonymize(df, fields=["fnr", "fornavn"])
@@ -81,12 +82,12 @@ def test_pseudonymize_dataframe(
     assert arg["files"]["data"][2] == Mimetypes.JSON
 
 
-@mock.patch("dapla.auth.AuthClient.fetch_google_credentials")
+@mock.patch("dapla.auth.AuthClient")
 @mock.patch(REQUESTS_POST)
 def test_pseudonymize_csv_file(
-    patched_post: mock.Mock, patched_fetch_google_credentials: mock.Mock, test_data_csv_file_path: str
+    patched_post: mock.Mock, patched_auth_client: mock.Mock, test_data_csv_file_path: str
 ) -> None:
-    patched_fetch_google_credentials.return_value = {"access_token": auth_token}
+    patched_auth_client.fetch_local_user.return_value = {"access_token": auth_token}
 
     pseudonymize(test_data_csv_file_path, fields=["fnr", "fornavn"])
     patched_post.assert_called_once()
@@ -97,12 +98,12 @@ def test_pseudonymize_csv_file(
     assert arg["files"]["data"][2] == Mimetypes.CSV
 
 
-@mock.patch("dapla.auth.AuthClient.fetch_google_credentials")
+@mock.patch("dapla.auth.AuthClient")
 @mock.patch(REQUESTS_POST)
 def test_pseudonymize_file_handle(
-    patched_post: mock.Mock, patched_fetch_google_credentials: mock.Mock, test_data_json_file_path: str
+    patched_post: mock.Mock, patched_auth_client: mock.Mock, test_data_json_file_path: str
 ) -> None:
-    patched_fetch_google_credentials.return_value = {"access_token": auth_token}
+    patched_auth_client.fetch_local_user.return_value = {"access_token": auth_token}
     with open(test_data_json_file_path, "rb") as data:
         pseudonymize(data, fields=["fnr", "fornavn"])
     patched_post.assert_called_once()
@@ -113,12 +114,12 @@ def test_pseudonymize_file_handle(
     assert arg["files"]["data"][2] == Mimetypes.JSON
 
 
-@mock.patch("dapla.auth.AuthClient.fetch_google_credentials")
+@mock.patch("dapla.auth.AuthClient")
 @mock.patch(REQUESTS_POST)
 def test_pseudonymize_fsspec_file(
-    patched_post: mock.Mock, patched_fetch_google_credentials: mock.Mock, test_data_json_file_path: str
+    patched_post: mock.Mock, patched_auth_client: mock.Mock, test_data_json_file_path: str
 ) -> None:
-    patched_fetch_google_credentials.return_value = {"access_token": auth_token}
+    patched_auth_client.fetch_local_user.return_value = {"access_token": auth_token}
     fs = GCSFileSystem()
     with fs.open("gs://anaconda-public-data/iris/iris.csv", "rb") as data:
         pseudonymize(data, fields=["fnr", "fornavn"])
@@ -130,9 +131,9 @@ def test_pseudonymize_fsspec_file(
     assert arg["files"]["data"][2] == Mimetypes.CSV
 
 
-@mock.patch("dapla.auth.AuthClient.fetch_google_credentials")
-def test_pseudonymize_invalid_type(patched_fetch_google_credentials: mock.Mock, test_data_json_file_path: str) -> None:
-    patched_fetch_google_credentials.return_value = {"access_token": auth_token}
+@mock.patch("dapla.auth.AuthClient")
+def test_pseudonymize_invalid_type(patched_auth_client: mock.Mock, test_data_json_file_path: str) -> None:
+    patched_auth_client.fetch_local_user.return_value = {"access_token": auth_token}
 
     with open(test_data_json_file_path) as data:
         with suppress_type_checks():


### PR DESCRIPTION
Undo changes from last PR(#273). PseudoClient should use Dapla Toolbelt's 'fetch_local_user' when authenticating with 'Pseudo service'. The special case for Cloud Run is already handled by setting env variables.

https://github.com/statisticsnorway/dapla-toolbelt-pseudo/blob/2d779ad05d12ccdc22d11f97662c66e6b39e1589/src/dapla_pseudo/v1/ops.py#L266

This env var is set by the base image:
https://github.com/statisticsnorway/dapla-source-data-processor/blob/ce8d8c0295258c3732bb67a43d822730c494dd31/app/main.py#L28