### PR TITLE
Release 0.5.9

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dapla-toolbelt-pseudo"
-version = "0.5.8"
+version = "0.5.9"
 description = "Pseudonymization extensions for Dapla Toolbelt"
 authors = ["Team Skyinfrastruktur <dapla@ssb.no>"]
 license = "MIT"


### PR DESCRIPTION
Making an empty release because during the last release, the tag was already created which caused the deployment to PyPI failed
