### PR TITLE
Include Python 3.12

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ packages = [{ include = "dapla_pseudo", from = "src" }]
 Changelog = "https://github.com/statisticsnorway/dapla-toolbelt-pseudo/releases"
 
 [tool.poetry.dependencies]
-python = ">=3.10, <3.12" # This needs to be pinned in sync with SciPy.
+python = ">=3.10, <3.13" # This needs to be pinned in sync with SciPy.
 pydantic = ">=2.0"
 pyhumps = ">=3.8.0"
 types-requests = ">=2.28.11"


### PR DESCRIPTION
Now that SciPy supports 3.12, we can also do so
