### PR TITLE
Fixed auth to pypi

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,9 +62,6 @@ jobs:
       - name: Publish package on PyPI
         if: steps.check-version.outputs.tag
         uses: pypa/gh-action-pypi-publish@v1.8.11
-        with:
-          user: __token__
-          password: ${{ secrets.PYPI_TOKEN }}
 
       - name: Publish the release notes
         uses: release-drafter/release-drafter@v5.25.0


### PR DESCRIPTION
[dapla-toolbelt-pseudo](https://github.com/statisticsnorway/dapla-toolbelt-pseudo) is now a trusted publisher for statisticsnorway on PyPi