### PR TITLE
Fix Polars bug

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dapla-toolbelt-pseudo"
-version = "1.0.3"
+version = "1.0.4"
 description = "Pseudonymization extensions for Dapla"
 authors = ["Dapla Developers <dapla-platform-developers@ssb.no>"]
 license = "MIT"

--- a/src/dapla_pseudo/v1/result.py
+++ b/src/dapla_pseudo/v1/result.py
@@ -55,7 +55,8 @@ class Result:
         """
         match self._pseudo_response:
             case pl.DataFrame():
-                return self._pseudo_response
+                # Drop statement a workaround to https://github.com/pola-rs/polars/issues/7291
+                return self._pseudo_response.drop("__index_level_0__")
             case PseudoFileResponse(response, content_type, _):
                 output_format = SupportedOutputFileFormat(content_type.name.lower())
                 df = read_to_polars_df(

--- a/tests/v1/test_result.py
+++ b/tests/v1/test_result.py
@@ -1,0 +1,34 @@
+import io
+from pathlib import Path
+
+import pandas as pd
+import polars as pl
+
+from dapla_pseudo.v1.result import Result
+
+
+def test_result_index_level(tmp_path: Path) -> None:
+    # Related to https://github.com/pola-rs/polars/issues/7291
+    # If this test fails, hopefully this means that the issue is fixed
+    # and the test can be removed, as well as the code in Result
+    # removing the column "__index_level_0__"
+
+    df = pd.read_csv(
+        io.StringIO(
+            """
+            a	b
+            1	4
+            2	5
+            3	6
+        """
+        ),
+        sep="\t",
+    )
+
+    path_filtered = f"{tmp_path}/filtered.parquet"
+    df.query("b % 2 == 0").to_parquet(path_filtered, engine="pyarrow")
+    df_pl_filtered = pl.read_parquet(path_filtered)
+    assert "__index_level_0__" in df_pl_filtered.columns
+
+    df_result = Result(df_pl_filtered).to_polars()
+    assert "__index_level_0__" not in df_result.columns


### PR DESCRIPTION
This is a workaround to the following issue: https://github.com/pola-rs/polars/issues/7291

The issue arises when, if you pre-process data in certain ways in Pandas, and write the file to Parquet, Pandas writes some metadata in a separate column called `__index_level_0__` Polars, however, does not handle these columns, and renders the data unreadable when using `pl.read_parquet()`