### PR TITLE
Change default map-sid function

### DIFF
--- a/src/dapla_pseudo/constants.py
+++ b/src/dapla_pseudo/constants.py
@@ -32,7 +32,7 @@ class PseudoFunctionTypes(str, Enum):
     """Names of well known pseudo functions."""
 
     DAEAD = "daead"
-    MAP_SID = "map-sid"
+    MAP_SID = "map-sid-ff31"
     FF31 = "ff31"
     REDACT = "redact"
 

--- a/src/dapla_pseudo/v1/api_models.py
+++ b/src/dapla_pseudo/v1/api_models.py
@@ -137,10 +137,12 @@ class MapSidKeywordArgs(PseudoFunctionArgs):
         snapshot_date (date): The timestamp for the version of the SID catalogue.
             If not specified, will choose the latest version.
             The format is: YYYY-MM-DD, e.g. 2021-05-21
+        strategy: defines how encryption/decryption should handle non-alphabet characters
     """
 
     key_id: PredefinedKeys | str = PredefinedKeys.PAPIS_COMMON_KEY_1
     snapshot_date: t.Optional[date] = None
+    strategy: t.Optional[UnknownCharacterStrategy] = UnknownCharacterStrategy.SKIP
 
 
 class DaeadKeywordArgs(PseudoFunctionArgs):

--- a/tests/data/datadoc/expected_metadata_test_pseudonymize_sid.json
+++ b/tests/data/datadoc/expected_metadata_test_pseudonymize_sid.json
@@ -18,7 +18,7 @@
             "keyId": "papis-common-key-1"
           },
           {
-            "strategy": "SKIP"
+            "strategy": "skip"
           }
         ],
         "source_variable": null,

--- a/tests/data/datadoc/expected_metadata_test_pseudonymize_sid_null.json
+++ b/tests/data/datadoc/expected_metadata_test_pseudonymize_sid_null.json
@@ -18,7 +18,7 @@
             "keyId": "papis-common-key-1"
           },
           {
-            "strategy": "SKIP"
+            "strategy": "skip"
           }
         ],
         "source_variable": null,


### PR DESCRIPTION
The default function for mapping SID is now `map-sid-ff31`. The former `map-sid` function is deprecated.

Internal ticket no: DPSTAT-901