### PR TITLE
Repseudo in builder pattern

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,7 +202,6 @@ df = (
     .run()                                         # Apply pseudonymization to the selected field
     .to_polars()                                            # Get the result as a polars dataframe
 )
-pseudonymize(file_path="./data/personer.json", fields=["fnr", "fornavn"], key="ssb-common-key-1")
 
 # Pseudonymize a local file using a custom keyset:
 import json
@@ -268,12 +267,32 @@ result_df = (
 _Note that depseudonymization requires elevated access privileges._
 
 ### Repseudonymize
+Repseudonymize can either 1) Change the algorithm used to pseudonymize, and/or 2)
+change the key used in pseudonymization, while keeping the algorithm.
 
 ```python
-
-## TODO
+# Example: Repseudonymize from PAPIS-compatible encryption to Stable ID
+result_df = (
+    Repseudonymize.from_polars(df)                 # Specify what dataframe to use
+    .on_fields("fnr")                              # Select the field to pseudonymize
+    .from_papis_compatible_encryption()            # Select the pseudonymization algorithm previously used
+    .to_stable_id()                                # Select the new pseudonymization rule
+    .run()                                         # Apply pseudonymization to the selected field
+    .to_polars()                                   # Get the result as a polars dataframe
+)
 ```
 
+```python
+# Example: Repseudonymize with the same algorithm, but with a different key
+result_df = (
+    Repseudonymize.from_polars(df)                     # Specify what dataframe to use
+    .on_fields("fnr")                                  # Select the field to pseudonymize
+    .from_papis_compatible_encryption()                # Select the pseudonymization algorithm previously used
+    .to_papis_compatible_encryption(key_id="some-key") # Select the new pseudonymization rule
+    .run()                                             # Apply pseudonymization to the selected field
+    .to_polars()                                       # Get the result as a polars dataframe
+)
+```
 ### Datadoc
 
 Datadoc metadata is gathered while pseudonymizing, and can be seen like so:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -96,6 +96,7 @@ module = [
     "typeguard",
     "puremagic",
     "google.*",
+    "google.oauth2"
 ]
 ignore_missing_imports = true
 

--- a/src/dapla_pseudo/__init__.py
+++ b/src/dapla_pseudo/__init__.py
@@ -25,12 +25,14 @@ from dapla_pseudo.v1.api_models import PseudoKeyset
 from dapla_pseudo.v1.client import PseudoClient
 from dapla_pseudo.v1.depseudo import Depseudonymize
 from dapla_pseudo.v1.pseudo import Pseudonymize
+from dapla_pseudo.v1.repseudo import Repseudonymize
 from dapla_pseudo.v1.validation import Validator
 
 __all__ = [
     "PseudoClient",
     "Pseudonymize",
     "Depseudonymize",
+    "Repseudonymize",
     "Validator",
     "Field",
     "PseudoKeyset",

--- a/src/dapla_pseudo/v1/__init__.py
+++ b/src/dapla_pseudo/v1/__init__.py
@@ -5,13 +5,14 @@ from dapla_pseudo.v1.api_models import PseudoKeyset
 from dapla_pseudo.v1.client import PseudoClient
 from dapla_pseudo.v1.depseudo import Depseudonymize
 from dapla_pseudo.v1.pseudo import Pseudonymize
+from dapla_pseudo.v1.repseudo import Repseudonymize
 from dapla_pseudo.v1.validation import Validator
 
 __all__ = [
     "PseudoClient",
     "Pseudonymize",
     "Depseudonymize",
-    "Validator",
+    "RepseudonymizeValidator",
     "Field",
     "PseudoKeyset",
 ]

--- a/src/dapla_pseudo/v1/__init__.py
+++ b/src/dapla_pseudo/v1/__init__.py
@@ -12,7 +12,8 @@ __all__ = [
     "PseudoClient",
     "Pseudonymize",
     "Depseudonymize",
-    "RepseudonymizeValidator",
+    "Repseudonymize",
+    "Validator",
     "Field",
     "PseudoKeyset",
 ]

--- a/src/dapla_pseudo/v1/api_models.py
+++ b/src/dapla_pseudo/v1/api_models.py
@@ -11,6 +11,7 @@ from pydantic import ConfigDict
 from pydantic import FieldSerializationInfo
 from pydantic import ValidationError
 from pydantic import field_serializer
+from pydantic import model_serializer
 
 from dapla_pseudo.constants import PredefinedKeys
 from dapla_pseudo.constants import PseudoFunctionTypes
@@ -188,6 +189,11 @@ class PseudoFunction(BaseModel):
         """Create the function representation as expected by pseudo service."""
         return f"{self.function_type}({self.kwargs})"
 
+    @model_serializer()
+    def serialize_model(self) -> str:
+        """Serialize the function as expected by the pseudo service."""
+        return f"{self.function_type}({self.kwargs})"
+
 
 class PseudoRule(APIModel):
     """A ``PseudoRule`` defines a pattern, a transformation function, and optionally a friendly name of the rule.
@@ -214,6 +220,35 @@ class PseudoRule(APIModel):
     ) -> str:
         """Explicit serialization of the 'func' field to coerce to string before serializing PseudoRule."""
         return str(func)
+
+
+class PseudoFieldRequest(APIModel):
+    """Model of the pseudo field request sent to the service."""
+
+    pseudo_func: PseudoFunction
+    name: str
+    values: list[str]
+    keyset: t.Optional[PseudoKeyset] = None
+
+
+class DepseudoFieldRequest(APIModel):
+    """Model of the depseudo field request sent to the service."""
+
+    pseudo_func: PseudoFunction
+    name: str
+    values: list[str]
+    keyset: t.Optional[PseudoKeyset] = None
+
+
+class RepseudoFieldRequest(APIModel):
+    """Model of the repseudo field request sent to the service."""
+
+    source_pseudo_func: PseudoFunction
+    target_pseudo_func: PseudoFunction
+    name: str
+    values: list[str]
+    source_keyset: t.Optional[PseudoKeyset] = None
+    target_keyset: t.Optional[PseudoKeyset] = None
 
 
 class PseudoConfig(APIModel):

--- a/src/dapla_pseudo/v1/baseclass.py
+++ b/src/dapla_pseudo/v1/baseclass.py
@@ -33,10 +33,10 @@ class _RuleConstructor:
             if custom_key
             else MapSidKeywordArgs(snapshot_date=convert_to_date(sid_snapshot_date))
         )
-        function = PseudoFunction(
+        pseudo_func = PseudoFunction(
             function_type=PseudoFunctionTypes.MAP_SID, kwargs=kwargs
         )
-        return self._rule_constructor(function)
+        return self._rule_constructor(pseudo_func)
 
     def _with_daead_encryption(
         self, custom_key: t.Optional[PredefinedKeys | str] = None
@@ -44,17 +44,19 @@ class _RuleConstructor:
         kwargs = (
             DaeadKeywordArgs(key_id=custom_key) if custom_key else DaeadKeywordArgs()
         )
-        function = PseudoFunction(
+        pseudo_func = PseudoFunction(
             function_type=PseudoFunctionTypes.DAEAD, kwargs=kwargs
         )
-        return self._rule_constructor(function)
+        return self._rule_constructor(pseudo_func)
 
     def _with_ff31_encryption(
         self, custom_key: t.Optional[PredefinedKeys | str] = None
     ) -> list[PseudoRule]:
         kwargs = FF31KeywordArgs(key_id=custom_key) if custom_key else FF31KeywordArgs()
-        function = PseudoFunction(function_type=PseudoFunctionTypes.FF31, kwargs=kwargs)
-        return self._rule_constructor(function)
+        pseudo_func = PseudoFunction(
+            function_type=PseudoFunctionTypes.FF31, kwargs=kwargs
+        )
+        return self._rule_constructor(pseudo_func)
 
     def _with_custom_function(self, function: PseudoFunction) -> list[PseudoRule]:
         return self._rule_constructor(function)

--- a/src/dapla_pseudo/v1/baseclass.py
+++ b/src/dapla_pseudo/v1/baseclass.py
@@ -41,15 +41,6 @@ class _RuleConstructor:
     def _with_daead_encryption(
         self, custom_key: t.Optional[PredefinedKeys | str] = None
     ) -> list[PseudoRule]:
-        """Pseudonymize the selected fields with the default encryption algorithm (DAEAD).
-
-        Args:
-            custom_key (Optional[PredefinedKeys | str], optional): Override the key to use for pseudonymization.
-                Must be one of the keys defined in PredefinedKeys. If not defined, uses the default key for this function (ssb-common-key-1)
-
-        Returns:
-            Self: The object configured to be mapped to stable ID
-        """
         kwargs = (
             DaeadKeywordArgs(key_id=custom_key) if custom_key else DaeadKeywordArgs()
         )
@@ -61,15 +52,6 @@ class _RuleConstructor:
     def _with_ff31_encryption(
         self, custom_key: t.Optional[PredefinedKeys | str] = None
     ) -> list[PseudoRule]:
-        """Pseudonymize the selected fields with a PAPIS-compatible encryption algorithm (FF31).
-
-        Args:
-            custom_key (Optional[PredefinedKeys | str], optional): Override the key to use for pseudonymization.
-                Must be one of the keys defined in PredefinedKeys. If not defined, uses the default key for this function (papis-common-key-1)
-
-        Returns:
-            Self: The object configured to be mapped to stable ID
-        """
         kwargs = FF31KeywordArgs(key_id=custom_key) if custom_key else FF31KeywordArgs()
         function = PseudoFunction(function_type=PseudoFunctionTypes.FF31, kwargs=kwargs)
         return self._rule_constructor(function)

--- a/src/dapla_pseudo/v1/baseclass.py
+++ b/src/dapla_pseudo/v1/baseclass.py
@@ -1,0 +1,87 @@
+import typing as t
+from datetime import date
+
+from dapla_pseudo.constants import PredefinedKeys
+from dapla_pseudo.constants import PseudoFunctionTypes
+from dapla_pseudo.utils import convert_to_date
+from dapla_pseudo.v1.api_models import DaeadKeywordArgs
+from dapla_pseudo.v1.api_models import FF31KeywordArgs
+from dapla_pseudo.v1.api_models import MapSidKeywordArgs
+from dapla_pseudo.v1.api_models import PseudoFunction
+from dapla_pseudo.v1.api_models import PseudoRule
+
+
+class _RuleConstructor:
+    """RuleConstructor constructs PseudoRules based on the supplied fields and called methods."""
+
+    def __init__(
+        self, fields: list[str], dataset_type: t.Literal["file", "dataframe"]
+    ) -> None:
+        self._fields = fields
+        self.dataset_type = dataset_type
+
+    def _map_to_stable_id_and_pseudonymize(
+        self,
+        sid_snapshot_date: t.Optional[str | date] = None,
+        custom_key: t.Optional[PredefinedKeys | str] = None,
+    ) -> list[PseudoRule]:
+        kwargs = (
+            MapSidKeywordArgs(
+                key_id=custom_key,
+                snapshot_date=convert_to_date(sid_snapshot_date),
+            )
+            if custom_key
+            else MapSidKeywordArgs(snapshot_date=convert_to_date(sid_snapshot_date))
+        )
+        function = PseudoFunction(
+            function_type=PseudoFunctionTypes.MAP_SID, kwargs=kwargs
+        )
+        return self._rule_constructor(function)
+
+    def _with_daead_encryption(
+        self, custom_key: t.Optional[PredefinedKeys | str] = None
+    ) -> list[PseudoRule]:
+        """Pseudonymize the selected fields with the default encryption algorithm (DAEAD).
+
+        Args:
+            custom_key (Optional[PredefinedKeys | str], optional): Override the key to use for pseudonymization.
+                Must be one of the keys defined in PredefinedKeys. If not defined, uses the default key for this function (ssb-common-key-1)
+
+        Returns:
+            Self: The object configured to be mapped to stable ID
+        """
+        kwargs = (
+            DaeadKeywordArgs(key_id=custom_key) if custom_key else DaeadKeywordArgs()
+        )
+        function = PseudoFunction(
+            function_type=PseudoFunctionTypes.DAEAD, kwargs=kwargs
+        )
+        return self._rule_constructor(function)
+
+    def _with_ff31_encryption(
+        self, custom_key: t.Optional[PredefinedKeys | str] = None
+    ) -> list[PseudoRule]:
+        """Pseudonymize the selected fields with a PAPIS-compatible encryption algorithm (FF31).
+
+        Args:
+            custom_key (Optional[PredefinedKeys | str], optional): Override the key to use for pseudonymization.
+                Must be one of the keys defined in PredefinedKeys. If not defined, uses the default key for this function (papis-common-key-1)
+
+        Returns:
+            Self: The object configured to be mapped to stable ID
+        """
+        kwargs = FF31KeywordArgs(key_id=custom_key) if custom_key else FF31KeywordArgs()
+        function = PseudoFunction(function_type=PseudoFunctionTypes.FF31, kwargs=kwargs)
+        return self._rule_constructor(function)
+
+    def _with_custom_function(self, function: PseudoFunction) -> list[PseudoRule]:
+        return self._rule_constructor(function)
+
+    def _rule_constructor(self, func: PseudoFunction) -> list[PseudoRule]:
+        # If we use the pseudonymize_file endpoint, we need a glob catch-all prefix.
+        rule_prefix = "**/" if self.dataset_type == "file" else ""
+        rules = [
+            PseudoRule(name=None, func=func, pattern=f"{rule_prefix}{field}")
+            for field in self._fields
+        ]
+        return rules

--- a/src/dapla_pseudo/v1/client.py
+++ b/src/dapla_pseudo/v1/client.py
@@ -13,11 +13,12 @@ from ulid import ULID
 from dapla_pseudo.constants import TIMEOUT_DEFAULT
 from dapla_pseudo.constants import Env
 from dapla_pseudo.types import FileSpecDecl
+from dapla_pseudo.v1.api_models import DepseudoFieldRequest
 from dapla_pseudo.v1.api_models import DepseudonymizeFileRequest
 from dapla_pseudo.v1.api_models import Mimetypes
-from dapla_pseudo.v1.api_models import PseudoFunction
-from dapla_pseudo.v1.api_models import PseudoKeyset
+from dapla_pseudo.v1.api_models import PseudoFieldRequest
 from dapla_pseudo.v1.api_models import PseudonymizeFileRequest
+from dapla_pseudo.v1.api_models import RepseudoFieldRequest
 from dapla_pseudo.v1.api_models import RepseudonymizeFileRequest
 
 
@@ -105,24 +106,13 @@ class PseudoClient:
     def _post_to_field_endpoint(
         self,
         path: str,
-        field_name: str,
-        values: list[str],
-        pseudo_func: t.Optional[PseudoFunction],
+        pseudo_field_request: (
+            PseudoFieldRequest | DepseudoFieldRequest | RepseudoFieldRequest
+        ),
         timeout: int,
-        keyset: t.Optional[PseudoKeyset] = None,
         stream: bool = False,
     ) -> requests.Response:
-        request: dict[str, t.Any] = {
-            "request": {
-                "name": field_name,
-                "values": values,
-                "pseudoFunc": str(pseudo_func),
-            }
-        }
-        if keyset:
-            print(keyset.model_dump(by_alias=True))
-            request["request"]["keyset"] = keyset.model_dump(by_alias=True)
-
+        print(pseudo_field_request.model_dump_json(by_alias=True))
         response = requests.post(
             url=f"{self.pseudo_service_url}/{path}",
             headers={
@@ -130,7 +120,7 @@ class PseudoClient:
                 "Content-Type": Mimetypes.JSON.value,
                 "X-Correlation-Id": PseudoClient._generate_new_correlation_id(),
             },
-            json=request,
+            json={"request": pseudo_field_request.model_dump_json(by_alias=True)},
             stream=stream,
             timeout=timeout,
         )

--- a/src/dapla_pseudo/v1/depseudo.py
+++ b/src/dapla_pseudo/v1/depseudo.py
@@ -17,6 +17,7 @@ from dapla_pseudo.constants import PseudoFunctionTypes
 from dapla_pseudo.types import FileLikeDatasetDecl
 from dapla_pseudo.utils import convert_to_date
 from dapla_pseudo.v1.api_models import DaeadKeywordArgs
+from dapla_pseudo.v1.api_models import DepseudoFieldRequest
 from dapla_pseudo.v1.api_models import DepseudonymizeFileRequest
 from dapla_pseudo.v1.api_models import FF31KeywordArgs
 from dapla_pseudo.v1.api_models import KeyWrapper
@@ -188,14 +189,17 @@ class Depseudonymize:
                 Returns:
                     tuple[str,pl.Series]: A tuple containing the field_name and the corresponding series.
                 """
+                request = DepseudoFieldRequest(
+                    pseudo_func=pseudo_func,
+                    keyset=KeyWrapper(self._pseudo_keyset).keyset,
+                    name=field_name,
+                    values=series.to_list(),
+                )
                 data, metadata = pseudonymize_operation_field(
                     path="depseudonymize/field",
-                    field_name=field_name,
-                    values=series.to_list(),
-                    pseudo_func=pseudo_func,
+                    pseudo_field_request=request,
                     timeout=self._timeout,
                     pseudo_client=self._pseudo_client,
-                    keyset=KeyWrapper(self._pseudo_keyset).keyset,
                 )
                 return field_name, data, metadata
 

--- a/src/dapla_pseudo/v1/pseudo.py
+++ b/src/dapla_pseudo/v1/pseudo.py
@@ -22,6 +22,7 @@ from dapla_pseudo.v1.api_models import KeyWrapper
 from dapla_pseudo.v1.api_models import MapSidKeywordArgs
 from dapla_pseudo.v1.api_models import Mimetypes
 from dapla_pseudo.v1.api_models import PseudoConfig
+from dapla_pseudo.v1.api_models import PseudoFieldRequest
 from dapla_pseudo.v1.api_models import PseudoFunction
 from dapla_pseudo.v1.api_models import PseudoKeyset
 from dapla_pseudo.v1.api_models import PseudonymizeFileRequest
@@ -187,14 +188,19 @@ class Pseudonymize:
                 Returns:
                     tuple[str,pl.Series]: A tuple containing the field_name and the corresponding series.
                 """
+                print(self._pseudo_keyset)
+                print(KeyWrapper(self._pseudo_keyset).keyset)
+                request = PseudoFieldRequest(
+                    pseudo_func=pseudo_func,
+                    keyset=KeyWrapper(self._pseudo_keyset).keyset,
+                    name=field_name,
+                    values=series.to_list(),
+                )
                 data, metadata = pseudonymize_operation_field(
                     path="pseudonymize/field",
-                    field_name=field_name,
-                    values=series.to_list(),
-                    pseudo_func=pseudo_func,
+                    pseudo_field_request=request,
                     timeout=self._timeout,
                     pseudo_client=self._pseudo_client,
-                    keyset=KeyWrapper(self._pseudo_keyset).keyset,
                 )
                 return field_name, data, metadata
 

--- a/src/dapla_pseudo/v1/pseudo.py
+++ b/src/dapla_pseudo/v1/pseudo.py
@@ -188,8 +188,6 @@ class Pseudonymize:
                 Returns:
                     tuple[str,pl.Series]: A tuple containing the field_name and the corresponding series.
                 """
-                print(self._pseudo_keyset)
-                print(KeyWrapper(self._pseudo_keyset).keyset)
                 request = PseudoFieldRequest(
                     pseudo_func=pseudo_func,
                     keyset=KeyWrapper(self._pseudo_keyset).keyset,

--- a/src/dapla_pseudo/v1/pseudo_commons.py
+++ b/src/dapla_pseudo/v1/pseudo_commons.py
@@ -252,8 +252,6 @@ def pseudonymize_operation_field(
     )
     payload = json.loads(response.content.decode("utf-8"))
     data = payload["data"]
-    print(payload["logs"])
-    print(payload["metrics"])
     metadata = RawPseudoMetadata(
         field_name=field_name,
         logs=payload["logs"],

--- a/src/dapla_pseudo/v1/pseudo_commons.py
+++ b/src/dapla_pseudo/v1/pseudo_commons.py
@@ -252,6 +252,8 @@ def pseudonymize_operation_field(
     )
     payload = json.loads(response.content.decode("utf-8"))
     data = payload["data"]
+    print(payload["logs"])
+    print(payload["metrics"])
     metadata = RawPseudoMetadata(
         field_name=field_name,
         logs=payload["logs"],

--- a/src/dapla_pseudo/v1/repseudo.py
+++ b/src/dapla_pseudo/v1/repseudo.py
@@ -291,6 +291,9 @@ class Repseudonymize:
                     Latest if unspecified. Format: YYYY-MM-DD
                 custom_key (Optional[PredefinedKeys | str], optional): Override the key to use for pseudonymization.
                     Must be one of the keys defined in PredefinedKeys. If not defined, uses the default key for this function (papis-common-key-1)
+
+            Returns:
+                An object with methods to choose how the field should be pseudonymized.
             """
             rules = super()._map_to_stable_id_and_pseudonymize(
                 sid_snapshot_date, custom_key
@@ -300,18 +303,37 @@ class Repseudonymize:
         def from_default_encryption(
             self, custom_key: t.Optional[PredefinedKeys | str] = None
         ) -> "Repseudonymize._RepseudoFuncSelectorTarget":
+            """Claim that the selected fields were pseudonymized with default encryption.
+
+            Args:
+                custom_key (Optional[PredefinedKeys | str], optional): Override the key to use for pseudonymization.
+                    Must be one of the keys defined in PredefinedKeys. If not defined, uses the default key for this function (papis-common-key-1)
+
+            Returns:
+                An object with methods to choose how the field should be pseudonymized.
+            """
             rules = super()._with_daead_encryption(custom_key)
             return Repseudonymize._RepseudoFuncSelectorTarget(self.fields, rules)
 
         def from_papis_compatible_encryption(
             self, custom_key: t.Optional[PredefinedKeys | str] = None
         ) -> "Repseudonymize._RepseudoFuncSelectorTarget":
+            """Claim that the selected fields were pseudonymized with PAPIS-compatible encryption.
+
+            Args:
+                custom_key (Optional[PredefinedKeys | str], optional): Override the key to use for pseudonymization.
+                    Must be one of the keys defined in PredefinedKeys. If not defined, uses the default key for this function (papis-common-key-1)
+
+            Returns:
+                An object with methods to choose how the field should be pseudonymized.
+            """
             rules = super()._with_ff31_encryption(custom_key)
             return Repseudonymize._RepseudoFuncSelectorTarget(self.fields, rules)
 
         def from_custom_function(
             self, function: PseudoFunction
         ) -> "Repseudonymize._RepseudoFuncSelectorTarget":
+            """Claim that the selected fields were pseudonymized with a custom, specified Pseudo Function."""
             rules = super()._with_custom_function(function)
             return Repseudonymize._RepseudoFuncSelectorTarget(self.fields, rules)
 
@@ -331,6 +353,19 @@ class Repseudonymize:
             sid_snapshot_date: t.Optional[str | date] = None,
             custom_key: t.Optional[PredefinedKeys | str] = None,
         ) -> "Repseudonymize._Repseudonymizer":
+            """Map the selected fields to Stable ID, then pseudonymize with a PAPIS-compatible encryption.
+
+            In other words, this is a compound operation that both: 1) maps FNR to stable ID 2) then encrypts the Stable IDs.
+
+            Args:
+                sid_snapshot_date (Optional[str | date], optional): Date representing SID-catalogue version to use.
+                    Latest if unspecified. Format: YYYY-MM-DD
+                custom_key (Optional[PredefinedKeys | str], optional): Override the key to use for pseudonymization.
+                    Must be one of the keys defined in PredefinedKeys. If not defined, uses the default key for this function (papis-common-key-1)
+
+            Returns:
+                Self: The object configured to be mapped to stable ID
+            """
             rules = super()._map_to_stable_id_and_pseudonymize(
                 sid_snapshot_date, custom_key
             )
@@ -339,12 +374,30 @@ class Repseudonymize:
         def to_default_encryption(
             self, custom_key: t.Optional[PredefinedKeys | str] = None
         ) -> "Repseudonymize._Repseudonymizer":
+            """Pseudonymize the selected fields with the default encryption algorithm (DAEAD).
+
+            Args:
+                custom_key (Optional[PredefinedKeys | str], optional): Override the key to use for pseudonymization.
+                    Must be one of the keys defined in PredefinedKeys. If not defined, uses the default key for this function (ssb-common-key-1)
+
+            Returns:
+                Self: The object configured to be mapped to stable ID
+            """
             rules = super()._with_daead_encryption(custom_key)
             return Repseudonymize._Repseudonymizer(self.source_rules, rules)
 
         def to_papis_compatible_encryption(
             self, custom_key: t.Optional[PredefinedKeys | str] = None
         ) -> "Repseudonymize._Repseudonymizer":
+            """Pseudonymize the selected fields with a PAPIS-compatible encryption algorithm (FF31).
+
+            Args:
+                custom_key (Optional[PredefinedKeys | str], optional): Override the key to use for pseudonymization.
+                    Must be one of the keys defined in PredefinedKeys. If not defined, uses the default key for this function (papis-common-key-1)
+
+            Returns:
+                Self: The object configured to be mapped to stable ID
+            """
             rules = super()._with_ff31_encryption(custom_key)
             return Repseudonymize._Repseudonymizer(self.source_rules, rules)
 

--- a/src/dapla_pseudo/v1/repseudo.py
+++ b/src/dapla_pseudo/v1/repseudo.py
@@ -1,0 +1,332 @@
+"""Builder for submitting a pseudonymization request."""
+
+import os
+import typing as t
+from concurrent.futures import ThreadPoolExecutor
+from concurrent.futures import as_completed
+from datetime import date
+from typing import Optional
+
+import pandas as pd
+import polars as pl
+
+from dapla_pseudo.constants import TIMEOUT_DEFAULT
+from dapla_pseudo.constants import Env
+from dapla_pseudo.constants import PredefinedKeys
+from dapla_pseudo.types import FileLikeDatasetDecl
+from dapla_pseudo.v1.api_models import KeyWrapper
+from dapla_pseudo.v1.api_models import Mimetypes
+from dapla_pseudo.v1.api_models import PseudoConfig
+from dapla_pseudo.v1.api_models import PseudoFunction
+from dapla_pseudo.v1.api_models import PseudoKeyset
+from dapla_pseudo.v1.api_models import PseudonymizeFileRequest
+from dapla_pseudo.v1.api_models import PseudoRule
+from dapla_pseudo.v1.baseclass import _RuleConstructor
+from dapla_pseudo.v1.client import PseudoClient
+from dapla_pseudo.v1.pseudo_commons import File
+from dapla_pseudo.v1.pseudo_commons import PseudoFieldResponse
+from dapla_pseudo.v1.pseudo_commons import PseudoFileResponse
+from dapla_pseudo.v1.pseudo_commons import RawPseudoMetadata
+from dapla_pseudo.v1.pseudo_commons import get_file_data_from_dataset
+from dapla_pseudo.v1.pseudo_commons import pseudo_operation_file
+from dapla_pseudo.v1.pseudo_commons import pseudonymize_operation_field
+from dapla_pseudo.v1.result import Result
+
+
+class Repseudonymize:
+    """Starting point for pseudonymization of datasets.
+
+    This class should not be instantiated, only the static methods should be used.
+    """
+
+    dataset: File | pl.DataFrame
+
+    @staticmethod
+    def from_pandas(dataframe: pd.DataFrame) -> "Repseudonymize._Repseudonymizer":
+        """Initialize a pseudonymization request from a pandas DataFrame."""
+        dataset: pl.DataFrame = pl.from_pandas(dataframe)
+        Repseudonymize.dataset = dataset
+        return Repseudonymize._Repseudonymizer()
+
+    @staticmethod
+    def from_polars(dataframe: pl.DataFrame) -> "Repseudonymize._Repseudonymizer":
+        """Initialize a pseudonymization request from a polars DataFrame."""
+        Repseudonymize.dataset = dataframe
+        return Repseudonymize._Repseudonymizer()
+
+    @staticmethod
+    def from_file(dataset: FileLikeDatasetDecl) -> "Repseudonymize._Repseudonymizer":
+        """Initialize a pseudonymization request from a pandas dataframe read from file.
+
+        Args:
+            dataset (FileLikeDatasetDecl): Either a path to the file to be read, or a file handle.
+
+        Returns:
+            _Pseudonymizer: An instance of the _Pseudonymizer class.
+
+        Examples:
+            # Read from bucket
+            from dapla import AuthClient
+            from dapla_pseudo import Pseudonymize
+            bucket_path = "gs://ssb-staging-dapla-felles-data-delt/felles/smoke-tests/fruits/data.parquet"
+            field_selector = Pseudonymize.from_file(bucket_path)
+
+            # Read from local filesystem
+            from dapla_pseudo import Pseudonymize
+
+            local_path = "some_file.csv"
+            field_selector = Pseudonymize.from_file(local_path))
+        """
+        file_handle, content_type = get_file_data_from_dataset(dataset)
+        Repseudonymize.dataset = File(file_handle, content_type)
+        return Repseudonymize._Repseudonymizer()
+
+    class _Repseudonymizer:
+        """Select one or multiple fields to be pseudonymized."""
+
+        source_rules: t.ClassVar[list[PseudoRule]] = []
+        target_rules: t.ClassVar[list[PseudoRule]] = []
+
+        def __init__(
+            self,
+            source_rules: t.Optional[list[PseudoRule]] = None,
+            target_rules: t.Optional[list[PseudoRule]] = None,
+        ) -> None:
+            """Initialize the class."""
+            if source_rules is None or target_rules is None:
+                # Because the "source_rules" and "target_rules" are static class variables,
+                # we need to reset the lists when the first call to "_Repseudonymizer" is made.
+                # This is because if we were to use the base class "Repseudonymize" twice in the same file,
+                # the lists of rules would persist across runs.
+                # *This is very hacky*, but the alternative is to pass the rules through
+                # "_RepseudoFuncSelectorSource" and "_RepseudoFuncSelectorTarget", which would hurt readability
+                Repseudonymize._Repseudonymizer.source_rules = []
+                Repseudonymize._Repseudonymizer.target_rules = []
+            else:
+                Repseudonymize._Repseudonymizer.source_rules.extend(source_rules)
+                Repseudonymize._Repseudonymizer.target_rules.extend(target_rules)
+
+            self._pseudo_keyset: Optional[PseudoKeyset | str] = None
+            self._timeout: int
+            self._pseudo_client: PseudoClient = PseudoClient(
+                pseudo_service_url=os.getenv(Env.PSEUDO_SERVICE_URL),
+                auth_token=os.getenv(Env.PSEUDO_SERVICE_AUTH_TOKEN),
+            )
+
+        def on_fields(
+            self, *fields: str
+        ) -> "Repseudonymize._RepseudoFuncSelectorSource":
+            """Specify one or multiple fields to be pseudonymized."""
+            return Repseudonymize._RepseudoFuncSelectorSource(list(fields))
+
+        def run(
+            self,
+            custom_keyset: Optional[PseudoKeyset | str] = None,
+            timeout: int = TIMEOUT_DEFAULT,
+        ) -> Result:
+            """Pseudonymize the dataset.
+
+            Args:
+                custom_keyset (PseudoKeyset, optional): The pseudonymization keyset to use. Defaults to None.
+                timeout (int): The timeout in seconds for the API call. Defaults to TIMEOUT_DEFAULT.
+
+            Raises:
+                ValueError: If no dataset has been provided, no fields have been provided, or the dataset is of an unsupported type.
+
+            Returns:
+                Result: The pseudonymized dataset and the associated metadata.
+            """
+            if Repseudonymize.dataset is None:
+                raise ValueError("No dataset has been provided.")
+
+            if (
+                Repseudonymize._Repseudonymizer.source_rules == []
+                or Repseudonymize._Repseudonymizer.target_rules
+            ):
+                raise ValueError(
+                    "No fields have been provided. Use the 'on_fields' method."
+                )
+
+            if custom_keyset is not None:
+                self._pseudo_keyset = custom_keyset
+
+            self._timeout = timeout
+            match Repseudonymize.dataset:  # Differentiate between file and DataFrame
+                case File():
+                    return self._repseudonymize_file()
+                case pl.DataFrame():
+                    return self._repseudonymize_field()
+                case _ as invalid_dataset:
+                    raise ValueError(
+                        f"Unsupported data type: {type(invalid_dataset)}. Should only be DataFrame or file-like type."
+                    )
+
+        def _repseudonymize_file(self) -> Result:
+            """Pseudonymize the entire file."""
+            # Need to type-cast explicitly. We know that Pseudonymize.dataset is a "File" if we reach this method.
+            file = t.cast(File, Repseudonymize.dataset)
+
+            pseudonymize_request = PseudonymizeFileRequest(
+                pseudo_config=PseudoConfig(
+                    rules=self._rules,
+                    keysets=KeyWrapper(self._pseudo_keyset).keyset_list(),
+                ),
+                target_content_type=Mimetypes.JSON,
+                target_uri=None,
+                compression=None,
+            )
+
+            pseudo_response: PseudoFileResponse = pseudo_operation_file(
+                file_handle=file.file_handle,
+                pseudo_operation_request=pseudonymize_request,
+                input_content_type=file.content_type,
+            )
+
+            return Result(pseudo_response=pseudo_response)
+
+        def _repseudonymize_field(self) -> Result:
+            """Pseudonymizes the specified fields in the DataFrame using the provided pseudonymization function.
+
+            The pseudonymization is performed in parallel. After the parallel processing is finished,
+            the pseudonymized fields replace the original fields in the DataFrame stored in `self._dataframe`.
+
+            Returns:
+                Result: Containing the pseudonymized 'self._dataframe' and the associated metadata.
+            """
+
+            def repseudonymize_field_runner(
+                field_name: str, series: pl.Series, pseudo_func: PseudoFunction
+            ) -> tuple[str, pl.Series, RawPseudoMetadata]:
+                """Function that performs the pseudonymization on a pandas Series.
+
+                Args:
+                    field_name (str):  The name of the field.
+                    series (pl.Series): The pandas Series containing the values to be pseudonymized.
+                    pseudo_func (PseudoFunction): The pseudonymization function to apply to the values.
+
+                Returns:
+                    tuple[str,pl.Series]: A tuple containing the field_name and the corresponding series.
+                """
+                data, metadata = pseudonymize_operation_field(
+                    path="pseudonymize/field",
+                    field_name=field_name,
+                    values=series.to_list(),
+                    pseudo_func=pseudo_func,
+                    timeout=self._timeout,
+                    pseudo_client=self._pseudo_client,
+                    keyset=KeyWrapper(self._pseudo_keyset).keyset,
+                )
+                return field_name, data, metadata
+
+            dataframe = t.cast(pl.DataFrame, Repseudonymize.dataset)
+            # Execute the pseudonymization API calls in parallel
+            with ThreadPoolExecutor() as executor:
+                pseudonymized_field: dict[str, pl.Series] = {}
+                raw_metadata_fields: list[RawPseudoMetadata] = []
+                futures = [
+                    executor.submit(
+                        repseudonymize_field_runner,
+                        rule.pattern,
+                        dataframe[rule.pattern],
+                        rule.func,
+                    )
+                    for rule in self._rules
+                ]
+                # Wait for the futures to finish, then add each field to pseudonymized_field map
+                for future in as_completed(futures):
+                    field_name, data, raw_metadata = future.result()
+                    pseudonymized_field[field_name] = data
+                    raw_metadata_fields.append(raw_metadata)
+
+                pseudonymized_df = pl.DataFrame(pseudonymized_field)
+                dataframe = dataframe.update(pseudonymized_df)
+            return Result(
+                pseudo_response=PseudoFieldResponse(
+                    data=dataframe, raw_metadata=raw_metadata_fields
+                )
+            )
+
+    class _RepseudoFuncSelectorSource(_RuleConstructor):
+        def __init__(self, fields: list[str]):
+            dataset_type: t.Literal["dataframe", "file"] = (
+                "dataframe"
+                if isinstance(Repseudonymize.dataset, pl.DataFrame)
+                else "file"
+            )
+            self.fields = fields
+            super().__init__(fields, dataset_type)
+
+        def from_stable_id(
+            self,
+            sid_snapshot_date: t.Optional[str | date] = None,
+            custom_key: t.Optional[PredefinedKeys | str] = None,
+        ) -> "Repseudonymize._RepseudoFuncSelectorTarget":
+            """Claim that the selected fields were mapped to Stable ID, then pseudonymized with PAPIS-compatible encryption.
+
+            Args:
+                sid_snapshot_date (Optional[str | date], optional): Date representing SID-catalogue version that was used.
+                    Latest if unspecified. Format: YYYY-MM-DD
+                custom_key (Optional[PredefinedKeys | str], optional): Override the key to use for pseudonymization.
+                    Must be one of the keys defined in PredefinedKeys. If not defined, uses the default key for this function (papis-common-key-1)
+            """
+            rules = super()._map_to_stable_id_and_pseudonymize(
+                sid_snapshot_date, custom_key
+            )
+            return Repseudonymize._RepseudoFuncSelectorTarget(self.fields, rules)
+
+        def from_default_encryption(
+            self, custom_key: t.Optional[PredefinedKeys | str] = None
+        ) -> "Repseudonymize._RepseudoFuncSelectorTarget":
+            rules = super()._with_daead_encryption(custom_key)
+            return Repseudonymize._RepseudoFuncSelectorTarget(self.fields, rules)
+
+        def from_papis_compatible_encryption(
+            self, custom_key: t.Optional[PredefinedKeys | str] = None
+        ) -> "Repseudonymize._RepseudoFuncSelectorTarget":
+            rules = super()._with_ff31_encryption(custom_key)
+            return Repseudonymize._RepseudoFuncSelectorTarget(self.fields, rules)
+
+        def from_custom_function(
+            self, function: PseudoFunction
+        ) -> "Repseudonymize._RepseudoFuncSelectorTarget":
+            rules = super()._with_custom_function(function)
+            return Repseudonymize._RepseudoFuncSelectorTarget(self.fields, rules)
+
+    class _RepseudoFuncSelectorTarget(_RuleConstructor):
+        def __init__(self, fields: list[str], source_rules: list[PseudoRule]):
+            self.source_rules = source_rules
+
+            dataset_type: t.Literal["dataframe", "file"] = (
+                "dataframe"
+                if isinstance(Repseudonymize.dataset, pl.DataFrame)
+                else "file"
+            )
+            super().__init__(fields, dataset_type)
+
+        def to_stable_id(
+            self,
+            sid_snapshot_date: t.Optional[str | date] = None,
+            custom_key: t.Optional[PredefinedKeys | str] = None,
+        ) -> "Repseudonymize._Repseudonymizer":
+            rules = super()._map_to_stable_id_and_pseudonymize(
+                sid_snapshot_date, custom_key
+            )
+            return Repseudonymize._Repseudonymizer(self.source_rules, rules)
+
+        def to_default_encryption(
+            self, custom_key: t.Optional[PredefinedKeys | str] = None
+        ) -> "Repseudonymize._Repseudonymizer":
+            rules = super()._with_daead_encryption(custom_key)
+            return Repseudonymize._Repseudonymizer(self.source_rules, rules)
+
+        def to_papis_compatible_encryption(
+            self, custom_key: t.Optional[PredefinedKeys | str] = None
+        ) -> "Repseudonymize._Repseudonymizer":
+            rules = super()._with_ff31_encryption(custom_key)
+            return Repseudonymize._Repseudonymizer(self.source_rules, rules)
+
+        def to_custom_function(
+            self, function: PseudoFunction
+        ) -> "Repseudonymize._Repseudonymizer":
+            rules = super()._with_custom_function(function)
+            return Repseudonymize._Repseudonymizer(self.source_rules, rules)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -71,6 +71,38 @@ def df_personer_fnr_daead_encrypted() -> pl.DataFrame:
 
 
 @pytest.fixture
+def df_personer_fnr_ff31_encrypted() -> pl.DataFrame:
+    JSON_FILE = "tests/data/personer_pseudonymized_papis_compatible_encryption.json"
+    return pl.read_json(
+        JSON_FILE,
+        schema={
+            "fnr": pl.String,
+            "fornavn": pl.String,
+            "etternavn": pl.String,
+            "kjonn": pl.String,
+            "fodselsdato": pl.String,
+        },
+    )
+
+
+@pytest.fixture
+def df_personer_daead_encrypted_ssb_common_key_2() -> pl.DataFrame:
+    CSV_FILE = (
+        "tests/data/personer_pseudonymized_default_encryption_ssb_common_key_2.csv"
+    )
+    return pl.read_csv(
+        CSV_FILE,
+        schema={
+            "fnr": pl.String,
+            "fornavn": pl.String,
+            "etternavn": pl.String,
+            "kjonn": pl.String,
+            "fodselsdato": pl.String,
+        },
+    )
+
+
+@pytest.fixture
 def df_personer_pseudo_stable_id() -> pl.DataFrame:
     JSON_FILE = "tests/data/person_3_sid_deid.json"
     return pl.read_json(

--- a/tests/data/personer_pseudonymized_default_encryption_ssb_common_key_2.csv
+++ b/tests/data/personer_pseudonymized_default_encryption_ssb_common_key_2.csv
@@ -1,0 +1,4 @@
+fnr,fornavn,etternavn,kjonn,fodselsdato
+AXzg5m91ZV4nzWpqYtdo+jfHIE40fLbDxug3Lr8Tamg=,Donald,Duck,M,020995
+AXzg5m9Ec/KlRWJBHfpwIsksDwmA7F/jhojyhBU8pec=,Mikke,Mus,M,060970
+AXzg5m/FALW/hNStYCElfyMR7/9rD398dEolAsISK6A=,Anton,Duck,M,180999

--- a/tests/integration/test_integration_repseudonymize.py
+++ b/tests/integration/test_integration_repseudonymize.py
@@ -1,0 +1,41 @@
+from collections.abc import Generator
+
+import polars as pl
+
+from dapla_pseudo import Repseudonymize
+from tests.integration.utils import integration_test
+from tests.integration.utils import setup
+
+
+@integration_test()
+def test_repseudonymize_from_default_encryption_to_fpe(
+    setup: Generator[None, None, None],
+    df_personer_fnr_ff31_encrypted: pl.DataFrame,
+    df_personer_fnr_daead_encrypted: pl.DataFrame,
+) -> None:
+    result_df = (
+        Repseudonymize.from_polars(df_personer_fnr_daead_encrypted)
+        .on_fields("fnr")
+        .from_default_encryption()
+        .to_papis_compatible_encryption()
+        .run()
+        .to_polars()
+    )
+    assert result_df.equals(df_personer_fnr_ff31_encrypted)
+
+
+@integration_test()
+def test_repseudonymize_change_keys(
+    setup: Generator[None, None, None],
+    df_personer_daead_encrypted_ssb_common_key_2: pl.DataFrame,
+    df_personer_fnr_daead_encrypted: pl.DataFrame,
+) -> None:
+    result = (
+        Repseudonymize.from_polars(df_personer_fnr_daead_encrypted)
+        .on_fields("fnr")
+        .from_default_encryption()
+        .to_default_encryption(custom_key="ssb-common-key-2")
+        .run()
+        .to_polars()
+    )
+    assert result.equals(df_personer_daead_encrypted_ssb_common_key_2)

--- a/tests/v1/test_repseudo.py
+++ b/tests/v1/test_repseudo.py
@@ -1,0 +1,373 @@
+import typing as t
+from unittest.mock import ANY
+from unittest.mock import MagicMock
+from unittest.mock import Mock
+from unittest.mock import patch
+
+import pandas as pd
+import polars as pl
+import pytest
+from google.auth.exceptions import DefaultCredentialsError
+
+from dapla_pseudo.constants import TIMEOUT_DEFAULT
+from dapla_pseudo.constants import PseudoFunctionTypes
+from dapla_pseudo.exceptions import FileInvalidError
+from dapla_pseudo.exceptions import NoFileExtensionError
+from dapla_pseudo.v1.api_models import DaeadKeywordArgs
+from dapla_pseudo.v1.api_models import FF31KeywordArgs
+from dapla_pseudo.v1.api_models import KeyWrapper
+from dapla_pseudo.v1.api_models import MapSidKeywordArgs
+from dapla_pseudo.v1.api_models import Mimetypes
+from dapla_pseudo.v1.api_models import PseudoConfig
+from dapla_pseudo.v1.api_models import PseudoFunction
+from dapla_pseudo.v1.api_models import PseudoKeyset
+from dapla_pseudo.v1.api_models import PseudoRule
+from dapla_pseudo.v1.api_models import RepseudoFieldRequest
+from dapla_pseudo.v1.api_models import RepseudonymizeFileRequest
+from dapla_pseudo.v1.client import PseudoClient
+from dapla_pseudo.v1.pseudo_commons import File
+from dapla_pseudo.v1.pseudo_commons import RawPseudoMetadata
+from dapla_pseudo.v1.pseudo_commons import pseudonymize_operation_field
+from dapla_pseudo.v1.repseudo import Repseudonymize
+from dapla_pseudo.v1.result import Result
+
+PKG = "dapla_pseudo.v1.repseudo"
+TEST_FILE_PATH = "tests/v1/test_files"
+
+
+def mock_return_pseudonymize_operation_field(
+    patch_pseudonymize_operation_field: Mock,
+) -> None:
+    patch_pseudonymize_operation_field.return_value = (
+        pl.Series(["e1", "e2", "e3"]),
+        RawPseudoMetadata(logs=[], metrics=[], datadoc=[], field_name="tester"),
+    )
+
+
+@patch("dapla_pseudo.v1.PseudoClient._post_to_field_endpoint")
+def test_builder_repseudonymize_minimal_call(
+    patched_post_to_field_endpoint: Mock,
+    df_personer_fnr_daead_encrypted: pl.DataFrame,
+    single_field_response: MagicMock,
+) -> None:
+    field_name = "fornavn"
+
+    patched_post_to_field_endpoint.return_value = single_field_response
+
+    pseudo_result = (
+        Repseudonymize.from_polars(df_personer_fnr_daead_encrypted)
+        .on_fields(field_name)
+        .from_default_encryption()
+        .to_default_encryption()
+        .run()
+    )
+    assert isinstance(pseudo_result, Result)
+    pseudo_dataframe = pseudo_result.to_pandas()
+
+    # TODO: Test for metadata values
+    # Check that the pseudonymized df has new values
+    assert pseudo_dataframe[field_name].tolist() == ["Donald", "Mikke", "Anton"]
+
+
+@patch("dapla_pseudo.v1.PseudoClient._post_to_field_endpoint")
+def test_single_field_pseudonymize_operation_field(
+    patched_post_to_field_endpoint: Mock, single_field_response: MagicMock
+) -> None:
+    patched_post_to_field_endpoint.return_value = single_field_response
+
+    source_pseudo_func = PseudoFunction(
+        function_type=PseudoFunctionTypes.MAP_SID,
+        kwargs=MapSidKeywordArgs(key_id="fake-key"),
+    )
+    target_pseudo_func = PseudoFunction(
+        function_type=PseudoFunctionTypes.FF31,
+        kwargs=FF31KeywordArgs(key_id="fake-key"),
+    )
+    req = RepseudoFieldRequest(
+        source_pseudo_func=source_pseudo_func,
+        target_pseudo_func=target_pseudo_func,
+        name="fornavn",
+        values=["1", "2", "3"],
+    )
+    data, _ = pseudonymize_operation_field(
+        "fake.endpoint",
+        req,
+        TIMEOUT_DEFAULT,
+        PseudoClient(pseudo_service_url="mock_url", auth_token="mock_token"),
+    )
+    assert data.to_list() == ["Donald", "Mikke", "Anton"]
+
+
+def test_depseudo_fields_selector_single_field(
+    df_personer_fnr_daead_encrypted: pl.DataFrame,
+) -> None:
+    assert Repseudonymize.from_polars(df_personer_fnr_daead_encrypted).on_fields(
+        "fornavn"
+    )._fields == ["fornavn"]
+
+
+def test_builder_fields_selector_single_field_pandas(
+    df_pandas_personer_fnr_daead_encrypted: pd.DataFrame,
+) -> None:
+    assert Repseudonymize.from_pandas(df_pandas_personer_fnr_daead_encrypted).on_fields(
+        "fornavn"
+    )._fields == ["fornavn"]
+
+
+def test_builder_fields_selector_multiple_fields(
+    df_personer_fnr_daead_encrypted: pl.DataFrame,
+) -> None:
+    assert Repseudonymize.from_polars(df_personer_fnr_daead_encrypted).on_fields(
+        "fornavn", "fnr"
+    )._fields == [
+        "fornavn",
+        "fnr",
+    ]
+
+
+@patch(f"{PKG}.pseudonymize_operation_field")
+def test_builder_repseudo_function_selector_with_sid(
+    patch_pseudonymize_operation_field: MagicMock, df_personer: pl.DataFrame
+) -> None:
+    mock_return_pseudonymize_operation_field(patch_pseudonymize_operation_field)
+    Repseudonymize.from_polars(df_personer).on_fields(
+        "fnr"
+    ).from_default_encryption().to_stable_id().run()
+    source_pseudo_func = PseudoFunction(
+        function_type=PseudoFunctionTypes.DAEAD, kwargs=DaeadKeywordArgs()
+    )
+    target_pseudo_func = PseudoFunction(
+        function_type=PseudoFunctionTypes.MAP_SID, kwargs=MapSidKeywordArgs()
+    )
+    req = RepseudoFieldRequest(
+        source_pseudo_func=source_pseudo_func,
+        target_pseudo_func=target_pseudo_func,
+        name="fnr",
+        values=df_personer["fnr"].to_list(),
+    )
+    patch_pseudonymize_operation_field.assert_called_once_with(
+        path="repseudonymize/field",
+        pseudo_field_request=req,
+        timeout=TIMEOUT_DEFAULT,
+        pseudo_client=ANY,
+    )
+
+
+@patch(f"{PKG}.pseudo_operation_file")
+def test_builder_file_default(
+    patched_pseudo_operation_file: MagicMock, personer_pseudonymized_file_path: str
+) -> None:
+    mock_pseudo_file_response = Mock()
+    mock_pseudo_file_response.data = File(file_handle=Mock(), content_type=Mock())
+    patched_pseudo_operation_file.return_value = mock_pseudo_file_response
+
+    Repseudonymize.from_file(personer_pseudonymized_file_path).on_fields(
+        "fornavn"
+    ).from_default_encryption().to_default_encryption().run()
+
+    pseudo_config = PseudoConfig(
+        rules=[
+            PseudoRule(
+                name=None,
+                pattern="**/fornavn",
+                func=PseudoFunction(
+                    function_type=PseudoFunctionTypes.DAEAD,
+                    kwargs=DaeadKeywordArgs(),
+                ),
+            )
+        ],
+        keysets=KeyWrapper(None).keyset_list(),
+    )
+    repseudonymize_request = RepseudonymizeFileRequest(
+        source_pseudo_config=pseudo_config,
+        target_pseudo_config=pseudo_config,  # the same config used
+        target_content_type=Mimetypes.JSON,
+        target_uri=None,
+        compression=None,
+    )
+    file_dataset = t.cast(File, Repseudonymize.dataset)
+    patched_pseudo_operation_file.assert_called_once_with(
+        file_handle=file_dataset.file_handle,
+        pseudo_operation_request=repseudonymize_request,
+        input_content_type=Mimetypes.JSON,
+    )
+
+
+@patch(f"{PKG}.pseudo_operation_file")
+def test_builder_file_hierarchical(
+    patched_pseudo_operation_file: MagicMock,
+    personer_pseudonymized_hierarch_file_path: str,
+) -> None:
+    patched_pseudo_operation_file.return_value = Mock()
+    Repseudonymize.from_file(personer_pseudonymized_hierarch_file_path).on_fields(
+        "person_info/fnr"
+    ).from_default_encryption().to_default_encryption().run()
+    pseudo_config = PseudoConfig(
+        rules=[
+            PseudoRule(
+                name=None,
+                pattern="**/person_info/fnr",
+                func=PseudoFunction(
+                    function_type=PseudoFunctionTypes.DAEAD,
+                    kwargs=DaeadKeywordArgs(),
+                ),
+            )
+        ],
+        keysets=KeyWrapper(None).keyset_list(),
+    )
+    repseudonymize_request = RepseudonymizeFileRequest(
+        source_pseudo_config=pseudo_config,
+        target_pseudo_config=pseudo_config,
+        target_content_type=Mimetypes.JSON,
+        target_uri=None,
+        compression=None,
+    )
+    file_dataset = t.cast(File, Repseudonymize.dataset)
+    patched_pseudo_operation_file.assert_called_once_with(
+        file_handle=file_dataset.file_handle,
+        pseudo_operation_request=repseudonymize_request,
+        input_content_type=Mimetypes.JSON,
+    )
+
+
+@patch(f"{PKG}.pseudonymize_operation_field")
+def test_builder_pseudo_function_selector_custom(
+    patch_pseudonymize_operation_field: MagicMock, df_personer: pl.DataFrame
+) -> None:
+    mock_return_pseudonymize_operation_field(patch_pseudonymize_operation_field)
+    pseudo_func = PseudoFunction(
+        function_type=PseudoFunctionTypes.FF31, kwargs=FF31KeywordArgs()
+    )
+    Repseudonymize.from_polars(df_personer).on_fields("fnr").from_custom_function(
+        pseudo_func
+    ).to_custom_function(pseudo_func).run()
+
+    req = RepseudoFieldRequest(
+        source_pseudo_func=pseudo_func,
+        target_pseudo_func=pseudo_func,
+        name="fnr",
+        values=df_personer["fnr"].to_list(),
+    )
+
+    patch_pseudonymize_operation_field.assert_called_once_with(
+        path="repseudonymize/field",
+        pseudo_field_request=req,
+        timeout=TIMEOUT_DEFAULT,
+        pseudo_client=ANY,
+    )
+
+
+@patch(f"{PKG}.pseudonymize_operation_field")
+def test_builder_repseudo_keyset_differing_key(
+    patch_pseudonymize_operation_field: MagicMock, df_personer: pl.DataFrame
+) -> None:
+    mock_return_pseudonymize_operation_field(patch_pseudonymize_operation_field)
+
+    kek_uri = "gcp-kms://fake/pseudo-service-fake"
+    encrypted_keyset = "fake_keyset"
+    keyset_info = {
+        "primaryKeyId": 123,
+        "keyInfo": [
+            {
+                "typeUrl": "type.googleapis.com/google.crypto.tink.fake",
+                "status": "ENABLED",
+                "keyId": 123,
+                "outputPrefixType": "TINK",
+            }
+        ],
+    }
+    source_pseudo_func = PseudoFunction(
+        function_type=PseudoFunctionTypes.DAEAD,
+        kwargs=DaeadKeywordArgs(),
+    )
+    target_pseudo_func = PseudoFunction(
+        function_type=PseudoFunctionTypes.DAEAD,
+        kwargs=DaeadKeywordArgs(key_id="123"),
+    )
+    keyset = PseudoKeyset(
+        kek_uri=kek_uri, encrypted_keyset=encrypted_keyset, keyset_info=keyset_info
+    )
+
+    Repseudonymize.from_polars(df_personer).on_fields(
+        "fnr"
+    ).from_default_encryption().to_default_encryption(custom_key="123").run(
+        custom_target_keyset=keyset
+    )
+
+    req = RepseudoFieldRequest(
+        source_pseudo_func=source_pseudo_func,
+        target_pseudo_func=target_pseudo_func,
+        name="fnr",
+        values=df_personer["fnr"].to_list(),
+        target_keyset=keyset,
+    )
+
+    patch_pseudonymize_operation_field.assert_called_once_with(
+        path="repseudonymize/field",
+        pseudo_field_request=req,
+        timeout=TIMEOUT_DEFAULT,
+        pseudo_client=ANY,
+    )
+
+
+def test_builder_field_selector_multiple_fields(df_personer: pl.DataFrame) -> None:
+    fields = ["snr", "snr_mor", "snr_far"]
+    assert Repseudonymize.from_polars(df_personer).on_fields(*fields)._fields == [
+        f"{f}" for f in fields
+    ]
+
+
+def test_builder_from_file_not_a_file() -> None:
+    path = f"{TEST_FILE_PATH}/not/a/file.json"
+    with pytest.raises(FileNotFoundError):
+        Repseudonymize.from_file(path)
+
+
+def test_builder_from_file_no_file_extension() -> None:
+    path = f"{TEST_FILE_PATH}/file_no_extension"
+
+    with pytest.raises(NoFileExtensionError):
+        Repseudonymize.from_file(path)
+
+
+def test_builder_from_file_empty_file() -> None:
+    path = f"{TEST_FILE_PATH}/empty_file"
+
+    with pytest.raises(FileInvalidError):
+        Repseudonymize.from_file(path)
+
+
+@pytest.mark.parametrize("file_format", Mimetypes.__members__.keys())
+def test_builder_from_file(file_format: str) -> None:
+    # Test reading all supported file extensions
+    Repseudonymize.from_file(f"{TEST_FILE_PATH}/test.{file_format.lower()}")
+
+
+def test_builder_from_invalid_gcs_file() -> None:
+    invalid_gcs_path = "gs://invalid/path.json"
+    with pytest.raises((FileNotFoundError, DefaultCredentialsError)):
+        Repseudonymize.from_file(invalid_gcs_path)
+
+
+@patch(f"{PKG}.pseudonymize_operation_field")
+def test_builder_to_polars_from_polars_chaining(
+    patch_pseudonymize_operation_field: MagicMock, df_personer: pl.DataFrame
+) -> None:
+    def side_effect(**kwargs: t.Any) -> tuple[pl.Series, RawPseudoMetadata]:
+        name = kwargs["pseudo_field_request"]
+        return (
+            pl.Series([f"{name}1", f"{name}2", f"{name}3"]),
+            RawPseudoMetadata(logs=[], metrics=[], datadoc=[], field_name="tester"),
+        )
+
+    patch_pseudonymize_operation_field.side_effect = side_effect
+    fields_to_depseudonymize = "fnr", "fornavn", "etternavn"
+    result: pl.DataFrame = (
+        Repseudonymize.from_polars(df_personer)
+        .on_fields(*fields_to_depseudonymize)
+        .from_default_encryption()
+        .to_default_encryption()
+        .run()
+        .to_polars()
+    )
+    assert result is not None


### PR DESCRIPTION
This PR implements repseudo in the builder pattern. We also made a common class for building `PseudoRules`. This should probably be re-used in `pseudo` and `depseudo`. 