### PR TITLE
Fix Validator documentation. Convert to date in Validator

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,6 @@ A `sid_snapshot_date` can also be specified to validate that the field values ca
 
 ```python
 from dapla_pseudo import Validator
-from dapla_pseudo.utils import convert_to_date
 import polars as pl
 
 file_path="data/personer.csv"
@@ -128,7 +127,7 @@ result = (
     Validator.from_polars(df)
     .on_field("fnr")
     .validate_map_to_stable_id(
-        sid_snapshot_date=convert_to_date("2023-08-29")
+        sid_snapshot_date="2023-08-29"
     )
 )
 # Show metadata about the validation (e.g. which version of the SID catalog was used)

--- a/src/dapla_pseudo/utils.py
+++ b/src/dapla_pseudo/utils.py
@@ -33,7 +33,10 @@ def find_multipart_obj(obj_name: str, multipart_files_tuple: set[t.Any]) -> t.An
 
 
 def convert_to_date(sid_snapshot_date: t.Optional[date | str]) -> t.Optional[date]:
-    """Converts the SID version date to the 'date' type."""
+    """Converts the SID version date to the 'date' type, if it is a string.
+
+    If None, simply passes the None through the function.
+    """
     if isinstance(sid_snapshot_date, str):
         try:
             return date.fromisoformat(sid_snapshot_date)

--- a/src/dapla_pseudo/v1/client.py
+++ b/src/dapla_pseudo/v1/client.py
@@ -131,7 +131,7 @@ class PseudoClient:
         self,
         path: str,
         values: list[str],
-        sid_snapshot_date: t.Optional[str | date] = None,
+        sid_snapshot_date: t.Optional[date] = None,
         stream: bool = False,
     ) -> requests.Response:
         request: dict[str, t.Collection[str]] = {"fnrList": values}

--- a/src/dapla_pseudo/v1/validation.py
+++ b/src/dapla_pseudo/v1/validation.py
@@ -11,6 +11,7 @@ import pandas as pd
 import polars as pl
 import requests
 
+from dapla_pseudo.utils import convert_to_date
 from dapla_pseudo.utils import get_file_format_from_file_name
 from dapla_pseudo.v1.client import _client
 from dapla_pseudo.v1.pseudo_commons import PseudoFieldResponse
@@ -115,7 +116,7 @@ class Validator:
             response: requests.Response = _client()._post_to_sid_endpoint(
                 "sid/lookup/batch",
                 self._dataframe[self._field].to_list(),
-                sid_snapshot_date,
+                convert_to_date(sid_snapshot_date),
                 stream=True,
             )
             # The response content is received as a buffered byte stream from the server.


### PR DESCRIPTION
The Validator accepts both "str" and "date" as input types, so we don't need an explicit conversion to "date". 