### PR TITLE
Add ability to deserialize PseudoFunction from json

### DIFF
--- a/src/dapla_pseudo/__init__.py
+++ b/src/dapla_pseudo/__init__.py
@@ -22,6 +22,7 @@ __version__ = version("dapla_toolbelt_pseudo")
 
 from dapla_pseudo.v1.api_models import Field
 from dapla_pseudo.v1.api_models import PseudoKeyset
+from dapla_pseudo.v1.api_models import PseudoRule
 from dapla_pseudo.v1.client import PseudoClient
 from dapla_pseudo.v1.depseudo import Depseudonymize
 from dapla_pseudo.v1.pseudo import Pseudonymize

--- a/src/dapla_pseudo/v1/api_models.py
+++ b/src/dapla_pseudo/v1/api_models.py
@@ -195,7 +195,13 @@ class PseudoFunction(BaseModel):
     @model_validator(mode="before")
     @classmethod
     def deserialize_model(cls, data: str | dict[str, t.Any]) -> dict[str, t.Any]:
-        """Deserialise the json-formatted pseudo function to Python model."""
+        """Deserialize the shorthand string representation of a pseudo function to Python model.
+
+        This function parses the serialized version of a function like e.g. 'redact(placeholder=#)'
+        by splitting the function name (fun) from the arguments (args), and then constructing a
+        dict out of the args. Finally, the proper function type and kwargs are inferred from the
+        PseudoFunctionTypes enum.
+        """
         if isinstance(data, str):
             func: str
             args: str

--- a/src/dapla_pseudo/v1/api_models.py
+++ b/src/dapla_pseudo/v1/api_models.py
@@ -194,7 +194,7 @@ class PseudoFunction(BaseModel):
 
     @model_validator(mode="before")
     @classmethod
-    def deserialize_model(cls, data: str | dict) -> dict:
+    def deserialize_model(cls, data: str | dict[str, t.Any]) -> dict[str, t.Any]:
         """Deserialise the json-formatted pseudo function to Python model."""
         if isinstance(data, str):
             func: str
@@ -257,7 +257,7 @@ class PseudoRule(APIModel):
         return str(func)
 
     @classmethod
-    def from_json(cls, data: str) -> t.Any:
+    def from_json(cls, data: str | dict[str, t.Any]) -> t.Any:
         """Deserialise the json-formatted pseudo rule to Python model."""
         if isinstance(data, str):
             return super().model_validate(json.loads(data))

--- a/src/dapla_pseudo/v1/api_models.py
+++ b/src/dapla_pseudo/v1/api_models.py
@@ -256,6 +256,11 @@ class PseudoRule(APIModel):
         """Explicit serialization of the 'func' field to coerce to string before serializing PseudoRule."""
         return str(func)
 
+    @classmethod
+    def from_json(cls, data: str) -> t.Any:
+        """Deserialise the json-formatted pseudo rule to Python model."""
+        return super().model_validate(eval(data))
+
 
 class PseudoFieldRequest(APIModel):
     """Model of the pseudo field request sent to the service."""

--- a/src/dapla_pseudo/v1/api_models.py
+++ b/src/dapla_pseudo/v1/api_models.py
@@ -259,7 +259,10 @@ class PseudoRule(APIModel):
     @classmethod
     def from_json(cls, data: str) -> t.Any:
         """Deserialise the json-formatted pseudo rule to Python model."""
-        return super().model_validate(eval(data))
+        if isinstance(data, str):
+            return super().model_validate(json.loads(data))
+        else:
+            return super().model_validate(data)
 
 
 class PseudoFieldRequest(APIModel):

--- a/tests/v1/test_api_models.py
+++ b/tests/v1/test_api_models.py
@@ -121,8 +121,8 @@ def test_deserialize_function_with_extra_kwargs() -> None:
 
 def test_deserialize_pseudo_rule() -> None:
     assert PseudoRule.from_json(
-        "{'name': 'my-fule', 'pattern': '**/identifiers/*', 'func': 'ff31("
-        "keyId=papis-common-key-1,strategy=skip)'}"
+        '{"name":"my-fule","pattern":"**/identifiers/*","func":"ff31('
+        'keyId=papis-common-key-1,strategy=skip)"}'
     ) == (
         PseudoRule(
             name="my-fule",

--- a/tests/v1/test_api_models.py
+++ b/tests/v1/test_api_models.py
@@ -108,7 +108,9 @@ def test_serialize_function_with_extra_kwargs() -> None:
 
 
 def test_deserialize_function_with_extra_kwargs() -> None:
-    assert PseudoFunction.model_validate("ff31(keyId=papis-common-key-1,strategy=skip)") == (
+    assert PseudoFunction.model_validate(
+        "ff31(keyId=papis-common-key-1,strategy=skip)"
+    ) == (
         PseudoFunction(
             function_type=PseudoFunctionTypes.FF31,
             kwargs=FF31KeywordArgs(),

--- a/tests/v1/test_api_models.py
+++ b/tests/v1/test_api_models.py
@@ -61,16 +61,35 @@ def test_key_wrapper_with_keyset_json() -> None:
     assert key_wrapper.keyset == PseudoKeyset.model_validate(custom_keyset_dict)
 
 
-def test_pseudo_function() -> None:
-    assert "daead(keyId=ssb-common-key-1)" == str(
+def test_serialize_daead_function() -> None:
+    assert (
+        PseudoFunction(
+            function_type=PseudoFunctionTypes.DAEAD, kwargs=DaeadKeywordArgs()
+        ).model_dump()
+        == "daead(keyId=ssb-common-key-1)"
+    )
+
+
+def test_deserialize_daead_function() -> None:
+    assert PseudoFunction.model_validate("daead(keyId=ssb-common-key-1)") == (
         PseudoFunction(
             function_type=PseudoFunctionTypes.DAEAD, kwargs=DaeadKeywordArgs()
         )
     )
 
 
-def test_redact_function() -> None:
-    assert "redact(placeholder=#)" == str(
+def test_serialize_redact_function() -> None:
+    assert (
+        PseudoFunction(
+            function_type=PseudoFunctionTypes.REDACT,
+            kwargs=RedactKeywordArgs(placeholder="#"),
+        ).model_dump()
+        == "redact(placeholder=#)"
+    )
+
+
+def test_deserialize_redact_function() -> None:
+    assert PseudoFunction.model_validate("redact(placeholder=#)") == (
         PseudoFunction(
             function_type=PseudoFunctionTypes.REDACT,
             kwargs=RedactKeywordArgs(placeholder="#"),
@@ -78,8 +97,18 @@ def test_redact_function() -> None:
     )
 
 
-def test_pseudo_function_with_extra_kwargs() -> None:
-    assert "ff31(keyId=papis-common-key-1,strategy=skip)" == str(
+def test_serialize_function_with_extra_kwargs() -> None:
+    assert (
+        PseudoFunction(
+            function_type=PseudoFunctionTypes.FF31,
+            kwargs=FF31KeywordArgs(),
+        ).model_dump()
+        == "ff31(keyId=papis-common-key-1,strategy=skip)"
+    )
+
+
+def test_deserialize_function_with_extra_kwargs() -> None:
+    assert PseudoFunction.model_validate("ff31(keyId=papis-common-key-1,strategy=skip)") == (
         PseudoFunction(
             function_type=PseudoFunctionTypes.FF31,
             kwargs=FF31KeywordArgs(),

--- a/tests/v1/test_api_models.py
+++ b/tests/v1/test_api_models.py
@@ -6,6 +6,7 @@ from dapla_pseudo.v1.api_models import FF31KeywordArgs
 from dapla_pseudo.v1.api_models import KeyWrapper
 from dapla_pseudo.v1.api_models import PseudoFunction
 from dapla_pseudo.v1.api_models import PseudoKeyset
+from dapla_pseudo.v1.api_models import PseudoRule
 from dapla_pseudo.v1.api_models import RedactKeywordArgs
 
 TEST_FILE_PATH = "tests/v1/test_files"
@@ -114,5 +115,21 @@ def test_deserialize_function_with_extra_kwargs() -> None:
         PseudoFunction(
             function_type=PseudoFunctionTypes.FF31,
             kwargs=FF31KeywordArgs(),
+        )
+    )
+
+
+def test_deserialize_pseudo_rule() -> None:
+    assert PseudoRule.from_json(
+        "{'name': 'my-fule', 'pattern': '**/identifiers/*', 'func': 'ff31("
+        "keyId=papis-common-key-1,strategy=skip)'}"
+    ) == (
+        PseudoRule(
+            name="my-fule",
+            func=PseudoFunction(
+                function_type=PseudoFunctionTypes.FF31,
+                kwargs=FF31KeywordArgs(),
+            ),
+            pattern="**/identifiers/*",
         )
     )

--- a/tests/v1/test_api_models.py
+++ b/tests/v1/test_api_models.py
@@ -67,7 +67,7 @@ def test_serialize_daead_function() -> None:
         PseudoFunction(
             function_type=PseudoFunctionTypes.DAEAD, kwargs=DaeadKeywordArgs()
         ).__str__()
-        == 'daead(keyId=ssb-common-key-1)'
+        == "daead(keyId=ssb-common-key-1)"
     )
 
 

--- a/tests/v1/test_api_models.py
+++ b/tests/v1/test_api_models.py
@@ -66,8 +66,8 @@ def test_serialize_daead_function() -> None:
     assert (
         PseudoFunction(
             function_type=PseudoFunctionTypes.DAEAD, kwargs=DaeadKeywordArgs()
-        ).model_dump()
-        == "daead(keyId=ssb-common-key-1)"
+        ).__str__()
+        == 'daead(keyId=ssb-common-key-1)'
     )
 
 
@@ -84,7 +84,7 @@ def test_serialize_redact_function() -> None:
         PseudoFunction(
             function_type=PseudoFunctionTypes.REDACT,
             kwargs=RedactKeywordArgs(placeholder="#"),
-        ).model_dump()
+        ).__str__()
         == "redact(placeholder=#)"
     )
 
@@ -103,7 +103,7 @@ def test_serialize_function_with_extra_kwargs() -> None:
         PseudoFunction(
             function_type=PseudoFunctionTypes.FF31,
             kwargs=FF31KeywordArgs(),
-        ).model_dump()
+        ).__str__()
         == "ff31(keyId=papis-common-key-1,strategy=skip)"
     )
 

--- a/tests/v1/test_api_models.py
+++ b/tests/v1/test_api_models.py
@@ -63,10 +63,10 @@ def test_key_wrapper_with_keyset_json() -> None:
 
 
 def test_serialize_daead_function() -> None:
-    assert (
+    assert str(
         PseudoFunction(
             function_type=PseudoFunctionTypes.DAEAD, kwargs=DaeadKeywordArgs()
-        ).__str__()
+        )
         == "daead(keyId=ssb-common-key-1)"
     )
 
@@ -80,11 +80,11 @@ def test_deserialize_daead_function() -> None:
 
 
 def test_serialize_redact_function() -> None:
-    assert (
+    assert str(
         PseudoFunction(
             function_type=PseudoFunctionTypes.REDACT,
             kwargs=RedactKeywordArgs(placeholder="#"),
-        ).__str__()
+        )
         == "redact(placeholder=#)"
     )
 
@@ -99,11 +99,11 @@ def test_deserialize_redact_function() -> None:
 
 
 def test_serialize_function_with_extra_kwargs() -> None:
-    assert (
+    assert str(
         PseudoFunction(
             function_type=PseudoFunctionTypes.FF31,
             kwargs=FF31KeywordArgs(),
-        ).__str__()
+        )
         == "ff31(keyId=papis-common-key-1,strategy=skip)"
     )
 


### PR DESCRIPTION
One can now create a `PseudoRule` from json, and where the `PseudoFunction` is expressed by the shorthand serialized string format,  e.g. like this:
```
from dapla_pseudo import PseudoRule

rule = {
    'name': 'my-fule',
     'pattern': '**/identifiers/*',
     'func': 'redact(placeholder=#)'
}

PseudoRule.from_json(rule)
```
