### PR TITLE
Refactor internal methods.

### DIFF
--- a/src/dapla_pseudo/utils.py
+++ b/src/dapla_pseudo/utils.py
@@ -135,7 +135,7 @@ def build_pseudo_field_request(
                 raise ValueError("Found no target rules")
 
 
-def build_pseudo_dataset_request(
+def build_pseudo_file_request(
     pseudo_operation: PseudoOperation,
     rules: list[PseudoRule],  # "source rules" if repseudo
     custom_keyset: PseudoKeyset | str | None = None,

--- a/src/dapla_pseudo/v1/baseclasses.py
+++ b/src/dapla_pseudo/v1/baseclasses.py
@@ -21,8 +21,8 @@ from dapla_pseudo.constants import PredefinedKeys
 from dapla_pseudo.constants import PseudoFunctionTypes
 from dapla_pseudo.constants import PseudoOperation
 from dapla_pseudo.types import FileSpecDecl
-from dapla_pseudo.utils import build_pseudo_dataset_request
 from dapla_pseudo.utils import build_pseudo_field_request
+from dapla_pseudo.utils import build_pseudo_file_request
 from dapla_pseudo.utils import convert_to_date
 from dapla_pseudo.v1.client import PseudoClient
 from dapla_pseudo.v1.client import _extract_name
@@ -89,14 +89,14 @@ class _BasePseudonymizer:
                 )
                 pseudo_response = self._pseudonymize_field(pseudo_requests, timeout)
             case File():
-                pseudo_request = build_pseudo_dataset_request(
+                pseudo_request = build_pseudo_file_request(
                     self._pseudo_operation,
                     rules,
                     custom_keyset,
                     target_custom_keyset,
                     target_rules,
                 )
-                pseudo_response = self._pseudonymize_dataset(pseudo_request, timeout)
+                pseudo_response = self._pseudonymize_file(pseudo_request, timeout)
             case _ as invalid_dataset:
                 raise ValueError(
                     f"Unsupported data type: {type(invalid_dataset)}. Should only be DataFrame or file-like type."
@@ -156,7 +156,7 @@ class _BasePseudonymizer:
                 data=self._dataset, raw_metadata=raw_metadata_fields
             )
 
-    def _pseudonymize_dataset(
+    def _pseudonymize_file(
         self,
         pseudo_request: PseudoFileRequest | DepseudoFileRequest | RepseudoFileRequest,
         timeout: int,

--- a/tests/v1/unit/test_base_pseudonymizer.py
+++ b/tests/v1/unit/test_base_pseudonymizer.py
@@ -42,13 +42,13 @@ def test_execute_pseudo_operation_field(
     mocker: MockerFixture,
 ) -> None:
     """Purpose: Ensure that supported dataset types are handled and actually perform pseudonymization."""
-    mocker.patch(f"{PKG}.build_pseudo_dataset_request", return_value=Mock())
+    mocker.patch(f"{PKG}.build_pseudo_file_request", return_value=Mock())
     mocker.patch(f"{PKG}.build_pseudo_field_request", return_value=Mock())
     mock_pseudo_field = mocker.patch(
         f"{PKG}._BasePseudonymizer._pseudonymize_field", return_value=Mock()
     )
-    mock_pseudo_dataset = mocker.patch(
-        f"{PKG}._BasePseudonymizer._pseudonymize_dataset", return_value=Mock()
+    mock_pseudo_file = mocker.patch(
+        f"{PKG}._BasePseudonymizer._pseudonymize_file", return_value=Mock()
     )
 
     base = _BasePseudonymizer(pseudo_operation=pseudo_op, dataset=dataset)
@@ -66,7 +66,7 @@ def test_execute_pseudo_operation_field(
         case pl.DataFrame():
             mock_pseudo_field.assert_called_once()
         case File():
-            mock_pseudo_dataset.assert_called_once()
+            mock_pseudo_file.assert_called_once()
 
 
 def test_pseudonymize_field(
@@ -175,7 +175,7 @@ def test_pseudonymize_dataset(
         pseudo_operation=PseudoOperation.PSEUDONYMIZE, dataset=personer_file
     )
 
-    response = base._pseudonymize_dataset(req, timeout=ANY)
+    response = base._pseudonymize_file(req, timeout=ANY)
     metadata = response.raw_metadata
     assert isinstance(response, PseudoFileResponse)
     assert metadata.datadoc == expected_json["datadoc_metadata"]["pseudo_variables"]  # type: ignore[index]


### PR DESCRIPTION
The methods `build_pseudo_dataset_request` and `_pseudonymize_dataset` is renamed to `build_pseudo_file_request` and `_pseudonymize_file` since the operation interacts with the file endpoint.