### PR TITLE
Disable gcloud local cloud logging

### DIFF
--- a/tests/v1/integration/conftest.py
+++ b/tests/v1/integration/conftest.py
@@ -17,6 +17,9 @@ def setup() -> Generator[None, None, None]:
         # Setup step
         # Could not find a way to generate id tokes without a SA to impersonate.
         # Subprocess `glcoud auth` as a temporary workaround
+
+        # Need to disable local file logging to avoid getting gcloud perm error
+        subprocess.run(["gcloud", "config", "set", "core/disable_file_logging", "True"])
         id_token = subprocess.getoutput("gcloud auth print-identity-token")
         os.environ["PSEUDO_SERVICE_AUTH_TOKEN"] = id_token
         yield


### PR DESCRIPTION
This is necessary to run the integration tests locally. gcloud, in the newest version, wants to write all logs to a /root folder when fetching an id-token. For some reason, changing the verbosity in the `gcloud` command does not silence this warning in the token output. So, we need to disable local logging to get the result cleanly.
