### PR TITLE
Redact locally

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dapla-toolbelt-pseudo"
-version = "2.1.3"
+version = "2.2.0"
 description = "Pseudonymization extensions for Dapla"
 authors = ["Dapla Developers <dapla-platform-developers@ssb.no>"]
 license = "MIT"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -104,6 +104,25 @@ def df_personer_hierarchical_pseudonymized() -> pl.DataFrame:
 
 
 @pytest_cases.fixture()
+def df_personer_hierarchical_redacted() -> pl.DataFrame:
+    JSON_FILE = "tests/data/personer_hierarchical_redacted.json"
+    return pl.read_json(
+        JSON_FILE,
+        schema={
+            "person_info": pl.Struct(
+                [
+                    pl.Field("fnr", dtype=pl.String),
+                    pl.Field("fornavn", dtype=pl.String),
+                    pl.Field("etternavn", dtype=pl.String),
+                ]
+            ),
+            "kjonn": pl.String,
+            "fodselsdato": pl.String,
+        },
+    )
+
+
+@pytest_cases.fixture()
 def df_personer_hierarchical_inner_list() -> pl.DataFrame:
     JSON_FILE = "tests/data/personer_hierarchical_inner_list.json"
     return pl.read_json(

--- a/tests/data/datadoc/expected_metadata_test_pseudonymize_hierarchical_redact.json
+++ b/tests/data/datadoc/expected_metadata_test_pseudonymize_hierarchical_redact.json
@@ -1,0 +1,25 @@
+{
+    "document_version": "0.0.1",
+    "datadoc": null,
+    "pseudonymization": {
+        "document_version": "0.1.0",
+        "pseudo_dataset": null,
+        "pseudo_variables": [
+            {
+                "short_name": "fnr",
+                "data_element_path": "person_info.fnr",
+                "data_element_pattern": "**/person_info/fnr",
+                "stable_identifier_type": null,
+                "stable_identifier_version": null,
+                "encryption_algorithm": "REDACT",
+                "encryption_algorithm_parameters": [
+                    {
+                        "placeholder": ":"
+                    }
+                ],
+                "source_variable": null,
+                "source_variable_datatype": null
+            }
+        ]
+    }
+}

--- a/tests/data/personer_hierarchical_redacted.json
+++ b/tests/data/personer_hierarchical_redacted.json
@@ -1,0 +1,29 @@
+[
+  {
+    "person_info": {
+      "fnr": ":",
+      "fornavn": "Donald",
+      "etternavn": "Duck"
+    },
+    "kjonn": "M",
+    "fodselsdato": "020995"
+  },
+  {
+    "person_info": {
+      "fnr": ":",
+      "fornavn": "Mikke",
+      "etternavn": "Mus"
+    },
+    "kjonn": "M",
+    "fodselsdato": "060970"
+  },
+  {
+    "person_info": {
+      "fnr": ":",
+      "fornavn": "Anton",
+      "etternavn": "Duck"
+    },
+    "kjonn": "M",
+    "fodselsdato": "180999"
+  }
+]

--- a/tests/v1/integration/test_pseudonymize.py
+++ b/tests/v1/integration/test_pseudonymize.py
@@ -10,6 +10,7 @@ from dapla_pseudo.constants import PseudoFunctionTypes
 from dapla_pseudo.v1.models.core import DaeadKeywordArgs
 from dapla_pseudo.v1.models.core import PseudoFunction
 from dapla_pseudo.v1.models.core import PseudoRule
+from dapla_pseudo.v1.models.core import RedactKeywordArgs
 
 
 @pytest.mark.usefixtures("setup")
@@ -158,6 +159,38 @@ def test_pseudonymize_hierarchical(
         exclude_none=True
     )
     assert_frame_equal(result.to_polars(), df_personer_hierarchical_pseudonymized)
+
+
+@pytest.mark.usefixtures("setup")
+@integration_test()
+def test_pseudonymize_hierarchical_redact(
+    df_personer_hierarchical: pl.DataFrame,
+    df_personer_hierarchical_redacted: pl.DataFrame,
+) -> None:
+    rule = PseudoRule(
+        name="my-rule",
+        func=PseudoFunction(
+            function_type=PseudoFunctionTypes.REDACT,
+            kwargs=RedactKeywordArgs(placeholder=":"),
+        ),
+        pattern="**/person_info/fnr",
+        path="person_info/fnr",
+    )
+    result = (
+        Pseudonymize.from_polars(df_personer_hierarchical)
+        .add_rules(rule)
+        .run(hierarchical=True)
+    )
+
+    current_function_name = get_calling_function_name()
+    expected_metadata_container = get_expected_datadoc_metadata_container(
+        current_function_name
+    )
+
+    assert result.datadoc == expected_metadata_container.model_dump_json(
+        exclude_none=True
+    )
+    assert_frame_equal(result.to_polars(), df_personer_hierarchical_redacted)
 
 
 @pytest.mark.usefixtures("setup")


### PR DESCRIPTION
This PR makes it so that the library does redact-operations within the library - and does not make calls to Pseudo Service. A cursory test indicated something like 1000x improvement in performance (not very surprising).

Downside -> we need to duplicate metadata changes in both the library and the service. However, given the constraints on the automation tools we offer I think this is a worthwhile.

Also, SonarCloud is dumb and doesn't recognize our interation tests for coverage purposes :))

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/statisticsnorway/dapla-toolbelt-pseudo/410)
<!-- Reviewable:end -->
