### PR TITLE
Use synchronous requests when running in an env with an event loop

### DIFF
--- a/.cruft.json
+++ b/.cruft.json
@@ -1,6 +1,6 @@
 {
   "template": "https://github.com/statisticsnorway/ssb-pypitemplate.git",
-  "commit": "b427b1efa9bec3506a1fef209b456a8523c8e6bd",
+  "commit": "66884cffa5aa67ed505bb121009501b51cc4d847",
   "checkout": null,
   "context": {
     "cookiecutter": {
@@ -23,7 +23,8 @@
         "lstrip_blocks": true,
         "trim_blocks": true
       },
-      "_template": "https://github.com/statisticsnorway/ssb-pypitemplate.git"
+      "_template": "https://github.com/statisticsnorway/ssb-pypitemplate.git",
+      "_commit": "66884cffa5aa67ed505bb121009501b51cc4d847"
     }
   },
   "directory": null

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,73 @@
+name: "\U0001F41E Bug Report"
+description: Report a bug
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Please fill out the sections below to help everyone identify and fix the bug
+  - type: textarea
+    id: description
+    attributes:
+      label: Describe the bug
+      placeholder: A clear and concise description of what the bug is.
+    validations:
+      required: true
+  - type: textarea
+    id: reproduce
+    attributes:
+      label: To Reproduce
+      description: Steps to reproduce the behavior.
+      placeholder: |
+        1. Step 1...
+        2. Step 2...
+        3. Step 3...
+        4. Step 4...
+    validations:
+      required: false
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behaviour
+      placeholder: A clear and concise description of what you expected to happen.
+    validations:
+      required: false
+  - type: dropdown
+    id: platform
+    attributes:
+      label: Platforms and Environments
+      multiple: true
+      description: >
+        On which platforms does the bug occur?
+        The first four items are platforms in Statistics Norway.
+        You can select multiple platforms.
+      options:
+        - DaplaLab with vscode
+        - DaplaLab with Jupyter
+        - Jupyter on-prem
+        - Old Dapla with Jupyter
+        - Windows
+        - Linux
+        - macOS
+    validations:
+      required: true
+  - type: input
+    id: version
+    attributes:
+      label: Version
+      description: What version of our software are you running?
+      placeholder: 1.0.0
+    validations:
+      required: false
+  - type: textarea
+    id: logs
+    attributes:
+      label: Error messages or logs
+      description: Please copy and paste any relevant log output or error messages.
+      render: shell
+    validations:
+      required: false
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for reporting this issue! We will get back to you as soon as possible.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,17 @@
+name: "\U0001F381 Feature Request"
+description: Suggest a new feature or enhancment.
+labels: ["enhancement"]
+body:
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: >
+        Describe the feature or enhancement and explain why it should be implemented.
+        Include a code example if applicable.
+    validations:
+      required: true
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for reporting this issue! We will get back to you as soon as possible.

--- a/.github/workflows/constraints.txt
+++ b/.github/workflows/constraints.txt
@@ -1,5 +1,5 @@
-pip==24.0
-nox==2024.4.15
+pip==24.3
+nox==2024.10.9
 nox-poetry==1.0.3
-poetry==1.8.3
-virtualenv==20.26.2
+poetry==2.0.1
+virtualenv==20.28.1

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -31,10 +31,11 @@ jobs:
       - name: Install Poetry
         run: |
           pipx install --pip-args "-c ${{ github.workspace }}/.github/workflows/constraints.txt" poetry
+          pipx inject poetry poetry-plugin-export
           poetry --version
 
       - name: Set up Python
-        uses: actions/setup-python@v5.2.0
+        uses: actions/setup-python@v5.3.0
         with:
           python-version: "3.12"
           cache: "poetry"

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -20,6 +20,6 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Run Labeler
-        uses: crazy-max/ghaction-github-labeler@v5.0.0
+        uses: crazy-max/ghaction-github-labeler@v5.0.0  # Use this version until https://github.com/crazy-max/ghaction-github-labeler/issues/221 is fixed
         with:
           skip-delete: true

--- a/.github/workflows/pseudo-service-integration-test.yaml
+++ b/.github/workflows/pseudo-service-integration-test.yaml
@@ -57,6 +57,7 @@ jobs:
         pip install .
         pip install pytest
         pip install pytest_cases
+        pip install pytest_mock
     - name: Integration test
       env:
         PSEUDO_SERVICE_AUTH_TOKEN: ${{ steps.get-id-token.outputs.PSEUDO_SERVICE_AUTH_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
           fetch-depth: 2
 
       - name: Set up Python
-        uses: actions/setup-python@v5.2.0
+        uses: actions/setup-python@v5.3.0
         with:
           python-version: "3.12"
 
@@ -32,7 +32,8 @@ jobs:
 
       - name: Install Poetry
         run: |
-          pip install -c ${{ github.workspace }}/.github/workflows/constraints.txt poetry
+          pipx install --pip-args "-c ${{ github.workspace }}/.github/workflows/constraints.txt" poetry
+          pipx inject poetry poetry-plugin-export
           poetry --version
 
       - name: Check if there is a parent commit
@@ -61,7 +62,7 @@ jobs:
 
       - name: Publish package on PyPI
         if: steps.check-version.outputs.tag
-        uses: pypa/gh-action-pypi-publish@v1.10.1
+        uses: pypa/gh-action-pypi-publish@v1.12.3
 
       - name: Publish the release notes
         uses: release-drafter/release-drafter@v6.0.0

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,6 +7,9 @@ on:
       - master
   pull_request:
 
+env:
+  INTEGRATION_TESTS: FALSE
+
 jobs:
   tests:
     name: ${{ matrix.session }} ${{ matrix.python }} / ${{ matrix.os }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,8 +6,6 @@ on:
       - main
       - master
   pull_request:
-env:
-  INTEGRATION_TESTS: FALSE
 
 jobs:
   tests:
@@ -40,14 +38,28 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set up Python ${{ matrix.python }}
-        uses: actions/setup-python@v5.2.0
+        uses: actions/setup-python@v5.3.0
         with:
           python-version: ${{ matrix.python }}
-          cache: "pip" # caching pip dependencies
 
+      - name: Upgrade pip
+        run: |
+          pip install -c ${{ github.workspace }}/.github/workflows/constraints.txt pip
+          pip --version
+
+
+      - name: Upgrade pip in virtual environments
+        shell: python
+        run: |
+          import os
+          import pip
+
+          with open(os.environ["GITHUB_ENV"], mode="a") as io:
+              print(f"VIRTUALENV_PIP={pip.__version__}", file=io)
       - name: Install Poetry
         run: |
           pipx install --pip-args "-c ${{ github.workspace }}/.github/workflows/constraints.txt" poetry
+          pipx inject poetry poetry-plugin-export
           poetry --version
 
       - name: Install Nox
@@ -110,16 +122,18 @@ jobs:
           fetch-depth: 0 # Shallow clones should be disabled for a better relevancy of analysis
 
       - name: Set up Python
-        uses: actions/setup-python@v5.2.0
+        uses: actions/setup-python@v5.3.0
         with:
-          python-version: "3.12"
-          cache: "pip" # caching pip dependencies
-
+          python-version: "3.10"
+      - name: Upgrade pip
+        run: |
+          pip install -c ${{ github.workspace }}/.github/workflows/constraints.txt pip
+          pip --version
       - name: Install Poetry
         run: |
           pipx install --pip-args "-c ${{ github.workspace }}/.github/workflows/constraints.txt" poetry
+          pipx inject poetry poetry-plugin-export
           poetry --version
-
       - name: Install Nox
         run: |
           pipx install --pip-args "-c ${{ github.workspace }}/.github/workflows/constraints.txt" nox
@@ -153,4 +167,4 @@ jobs:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
         # No need to run SonarCloud analysis if dependabot update or token not defined
         if: env.SONAR_TOKEN != '' && (github.actor != 'dependabot[bot]')
-        uses: SonarSource/sonarcloud-github-action@v3.0.0
+        uses: SonarSource/sonarcloud-github-action@v3.1.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -62,7 +62,6 @@ repos:
         entry: darglint
         language: system
         types: [python]
-        stages: [manual]
       - id: ruff
         name: ruff
         entry: ruff check --fix --exit-non-zero-on-fix

--- a/src/dapla_pseudo/utils.py
+++ b/src/dapla_pseudo/utils.py
@@ -1,5 +1,6 @@
 """Utility functions for Dapla Pseudo."""
 
+import asyncio
 import io
 import os
 import typing as t
@@ -97,6 +98,18 @@ def redact_field(
     )
 
     return request.name, data, metadata
+
+
+def asyncio_loop_running() -> bool:
+    """Determins whether asyncio has a running event loop."""
+    try:
+        loop = asyncio.get_event_loop()
+        if loop.is_running():
+            return True
+        else:
+            return False
+    except RuntimeError:
+        return False
 
 
 def convert_to_date(sid_snapshot_date: date | str | None = None) -> date | None:

--- a/src/dapla_pseudo/utils.py
+++ b/src/dapla_pseudo/utils.py
@@ -25,6 +25,7 @@ from dapla_pseudo.v1.models.api import DepseudoFieldRequest
 from dapla_pseudo.v1.models.api import DepseudoFileRequest
 from dapla_pseudo.v1.models.api import PseudoFieldRequest
 from dapla_pseudo.v1.models.api import PseudoFileRequest
+from dapla_pseudo.v1.models.api import RawPseudoMetadata
 from dapla_pseudo.v1.models.api import RepseudoFieldRequest
 from dapla_pseudo.v1.models.api import RepseudoFileRequest
 from dapla_pseudo.v1.models.core import KeyWrapper
@@ -32,6 +33,7 @@ from dapla_pseudo.v1.models.core import Mimetypes
 from dapla_pseudo.v1.models.core import PseudoConfig
 from dapla_pseudo.v1.models.core import PseudoKeyset
 from dapla_pseudo.v1.models.core import PseudoRule
+from dapla_pseudo.v1.models.core import RedactKeywordArgs
 from dapla_pseudo.v1.mutable_dataframe import MutableDataFrame
 from dapla_pseudo.v1.supported_file_format import FORMAT_TO_MIMETYPE_FUNCTION
 from dapla_pseudo.v1.supported_file_format import SupportedOutputFileFormat
@@ -59,6 +61,42 @@ def find_multipart_obj(obj_name: str, multipart_files_tuple: set[t.Any]) -> t.An
         return matching_item[1]
     except StopIteration:
         return None
+
+
+def redact_field(
+    request: PseudoFieldRequest,
+) -> tuple[str, list[str], RawPseudoMetadata]:
+    """Perform the redact operation locally.
+
+    This is in order to avoid making unnecessary requests to the API.
+    """
+    kwargs = t.cast(RedactKeywordArgs, request.pseudo_func.kwargs)
+    if kwargs.placeholder is None:
+        raise ValueError("Placeholder needs to be set for Redact")
+    data = [kwargs.placeholder for _ in request.values]
+    # The above operation could be vectorized using something like Polars,
+    # however - the redact functionality is used mostly teams that use hierarchical
+    # data, i.e. with very small lists. The overhead of
+    # creating a Polars Series is probably not worth it.
+
+    metadata = RawPseudoMetadata(
+        field_name=request.name,
+        logs=[],
+        metrics=[],
+        datadoc=[
+            {
+                "short_name": request.name.split("/")[-1],
+                "data_element_path": request.name.replace("/", "."),
+                "data_element_pattern": request.pattern,
+                "encryption_algorithm": "REDACT",
+                "encryption_algorithm_parameters": [
+                    request.pseudo_func.kwargs.model_dump(exclude_none=True)
+                ],
+            }
+        ],
+    )
+
+    return request.name, data, metadata
 
 
 def convert_to_date(sid_snapshot_date: date | str | None = None) -> date | None:

--- a/src/dapla_pseudo/utils.py
+++ b/src/dapla_pseudo/utils.py
@@ -103,7 +103,7 @@ def redact_field(
 def asyncio_loop_running() -> bool:
     """Determins whether asyncio has a running event loop."""
     try:
-        loop = asyncio.get_event_loop()
+        loop = asyncio.get_running_loop()
         if loop.is_running():
             return True
         else:

--- a/src/dapla_pseudo/v1/baseclasses.py
+++ b/src/dapla_pseudo/v1/baseclasses.py
@@ -41,7 +41,6 @@ from dapla_pseudo.v1.models.core import Mimetypes
 from dapla_pseudo.v1.models.core import PseudoFunction
 from dapla_pseudo.v1.models.core import PseudoKeyset
 from dapla_pseudo.v1.models.core import PseudoRule
-from dapla_pseudo.v1.models.core import RedactKeywordArgs
 from dapla_pseudo.v1.mutable_dataframe import MutableDataFrame
 from dapla_pseudo.v1.result import Result
 
@@ -132,13 +131,32 @@ class _BasePseudonymizer:
         # Execute the pseudonymization API calls in parallel
 
         raw_metadata_fields: list[RawPseudoMetadata] = []
-        for field_name, data, raw_metadata in asyncio.run(
-            self._pseudo_client.post_to_field_endpoint(
+
+        try:
+            loop = asyncio.get_event_loop()
+            if loop.is_running():
+                loop_running = True
+            else:
+                loop_running = False
+        except RuntimeError:
+            loop_running = False
+
+        if loop_running:
+            result = self._pseudo_client.post_to_field_endpoint_sync(
                 path=f"{self._pseudo_operation.value}/field",
                 timeout=timeout,
                 pseudo_requests=pseudo_requests,
             )
-        ):
+        else:
+            result = asyncio.run(
+                self._pseudo_client.post_to_field_endpoint(
+                    path=f"{self._pseudo_operation.value}/field",
+                    timeout=timeout,
+                    pseudo_requests=pseudo_requests,
+                )
+            )
+
+        for field_name, data, raw_metadata in result:
             self._dataset.update(field_name, data)
             raw_metadata_fields.append(raw_metadata)
 
@@ -192,38 +210,6 @@ class _BasePseudonymizer:
             streamed=True,
             file_name=file_name,
         )
-
-    @staticmethod
-    def _redact_field(
-        request: PseudoFieldRequest,
-    ) -> tuple[str, list[str], RawPseudoMetadata]:
-        kwargs = cast(RedactKeywordArgs, request.pseudo_func.kwargs)
-        if kwargs.placeholder is None:
-            raise ValueError("Placeholder needs to be set for Redact")
-        data = [kwargs.placeholder for _ in request.values]
-        # The above operation could be vectorized using something like Polars,
-        # however - the redact functionality is used mostly teams that use hierarchical
-        # data, i.e. with very small lists. The overhead of
-        # creating a Polars Series is probably not worth it.
-
-        metadata = RawPseudoMetadata(
-            field_name=request.name,
-            logs=[],
-            metrics=[],
-            datadoc=[
-                {
-                    "short_name": request.name.split("/")[-1],
-                    "data_element_path": request.name.replace("/", "."),
-                    "data_element_pattern": request.pattern,
-                    "encryption_algorithm": "REDACT",
-                    "encryption_algorithm_parameters": [
-                        request.pseudo_func.kwargs.model_dump(exclude_none=True)
-                    ],
-                }
-            ],
-        )
-
-        return request.name, data, metadata
 
 
 class _BaseRuleConstructor:

--- a/src/dapla_pseudo/v1/baseclasses.py
+++ b/src/dapla_pseudo/v1/baseclasses.py
@@ -19,6 +19,7 @@ from dapla_pseudo.constants import PredefinedKeys
 from dapla_pseudo.constants import PseudoFunctionTypes
 from dapla_pseudo.constants import PseudoOperation
 from dapla_pseudo.types import FileSpecDecl
+from dapla_pseudo.utils import asyncio_loop_running
 from dapla_pseudo.utils import build_pseudo_field_request
 from dapla_pseudo.utils import build_pseudo_file_request
 from dapla_pseudo.utils import convert_to_date
@@ -132,16 +133,7 @@ class _BasePseudonymizer:
 
         raw_metadata_fields: list[RawPseudoMetadata] = []
 
-        try:
-            loop = asyncio.get_event_loop()
-            if loop.is_running():
-                loop_running = True
-            else:
-                loop_running = False
-        except RuntimeError:
-            loop_running = False
-
-        if loop_running:
+        if asyncio_loop_running():
             result = self._pseudo_client.post_to_field_endpoint_sync(
                 path=f"{self._pseudo_operation.value}/field",
                 timeout=timeout,

--- a/tests/data/datadoc/expected_metadata_test_pseudonymize_default_encryption_synchronous.json
+++ b/tests/data/datadoc/expected_metadata_test_pseudonymize_default_encryption_synchronous.json
@@ -1,0 +1,26 @@
+{
+    "document_version": "0.0.1",
+    "datadoc": null,
+    "pseudonymization": {
+        "document_version": "0.1.0",
+        "pseudo_dataset": null,
+        "pseudo_variables": [
+            {
+                "short_name": "fnr",
+                "data_element_path": "fnr",
+                "data_element_pattern": "/fnr",
+                "stable_identifier_type": null,
+                "stable_identifier_version": null,
+                "encryption_algorithm": "TINK-DAEAD",
+                "encryption_key_reference": "ssb-common-key-1",
+                "encryption_algorithm_parameters": [
+                    {
+                        "keyId": "ssb-common-key-1"
+                    }
+                ],
+                "source_variable": null,
+                "source_variable_datatype": null
+            }
+        ]
+    }
+}

--- a/tests/v1/integration/test_pseudonymize.py
+++ b/tests/v1/integration/test_pseudonymize.py
@@ -1,3 +1,5 @@
+import asyncio
+
 import polars as pl
 import pytest
 from polars.testing import assert_frame_equal
@@ -11,6 +13,7 @@ from dapla_pseudo.v1.models.core import DaeadKeywordArgs
 from dapla_pseudo.v1.models.core import PseudoFunction
 from dapla_pseudo.v1.models.core import PseudoRule
 from dapla_pseudo.v1.models.core import RedactKeywordArgs
+from dapla_pseudo.v1.result import Result
 
 
 @pytest.mark.usefixtures("setup")
@@ -255,3 +258,31 @@ def test_pseudonymize_hierarchical_inner_list(
     assert_frame_equal(
         result.to_polars(), df_personer_hierarchical_inner_list_pseudonymized
     )
+
+
+@pytest.mark.usefixtures("setup")
+@integration_test()
+def test_pseudonymize_default_encryption_synchronous(
+    df_personer: pl.DataFrame, df_personer_fnr_daead_encrypted: pl.DataFrame
+) -> None:
+    """Initialize an event loop to simulate running in an environment with a running event loop (e.g. Jupyter Notebook)."""
+
+    async def async_wrapper() -> Result:
+        """Simply presents asyncio with the correct interface in order to run the function in an event loop."""
+        return (
+            Pseudonymize.from_polars(df_personer)
+            .on_fields("fnr")
+            .with_default_encryption()
+            .run()
+        )
+
+    result = asyncio.run(async_wrapper())
+    current_function_name = get_calling_function_name()
+    expected_metadata_container = get_expected_datadoc_metadata_container(
+        current_function_name
+    )
+
+    assert result.datadoc == expected_metadata_container.model_dump_json(
+        exclude_none=True
+    )
+    assert_frame_equal(result.to_polars(), df_personer_fnr_daead_encrypted)

--- a/tests/v1/integration/test_pseudonymize.py
+++ b/tests/v1/integration/test_pseudonymize.py
@@ -3,6 +3,7 @@ import asyncio
 import polars as pl
 import pytest
 from polars.testing import assert_frame_equal
+from pytest_mock import MockerFixture
 from tests.v1.integration.utils import get_calling_function_name
 from tests.v1.integration.utils import get_expected_datadoc_metadata_container
 from tests.v1.integration.utils import integration_test
@@ -286,3 +287,32 @@ def test_pseudonymize_default_encryption_synchronous(
         exclude_none=True
     )
     assert_frame_equal(result.to_polars(), df_personer_fnr_daead_encrypted)
+
+
+@pytest.mark.usefixtures("setup")
+@integration_test()
+def test_pseudonymize_async_in_sync_env_raises_error(
+    df_personer: pl.DataFrame, mocker: MockerFixture
+) -> None:
+    """Initialize an event loop to simulate running in an environment with a running event loop (e.g. Jupyter Notebook)."""
+
+    async def async_wrapper() -> Result:
+        """Simply presents asyncio with the correct interface in order to run the function in an event loop."""
+        return (
+            Pseudonymize.from_polars(df_personer)
+            .on_fields("fnr")
+            .with_default_encryption()
+            .run()
+        )
+
+    mocker.patch(
+        "dapla_pseudo.v1.baseclasses.asyncio_loop_running",
+        return_value=False,
+    )
+
+    with pytest.raises(RuntimeError) as excinfo:
+        asyncio.run(async_wrapper())
+
+    assert "asyncio.run() cannot be called from a running event loop" in str(
+        excinfo.value
+    )


### PR DESCRIPTION
When running `dapla-toolbelt-pseudo` in an environment where programs are already being executed through an event loop (e.g Jupyter Notebook), this library, which also uses an event loop, cannot serve any requests. This is apparently a known issue with `asyncio`. This PR essentially restores the functionality removed in #412, but refactoring it into its own function. This library now detects whether the environment contains a running event loop, and uses synchronous requests if that is the case.

Also, rather embarassingly, #412 did remove the functionality introduced in #410, so this functionality has been re-introduced.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/statisticsnorway/dapla-toolbelt-pseudo/431)
<!-- Reviewable:end -->
