### PR TITLE
Construct a new builder from a previously generated result

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dapla-toolbelt-pseudo"
-version = "2.2.7"
+version = "2.2.8"
 description = "Pseudonymization extensions for Dapla"
 authors = ["Dapla Developers <dapla-platform-developers@ssb.no>"]
 license = "MIT"

--- a/src/dapla_pseudo/v1/repseudo.py
+++ b/src/dapla_pseudo/v1/repseudo.py
@@ -5,6 +5,7 @@ from datetime import date
 
 import pandas as pd
 import polars as pl
+from datadoc_model.model import MetadataContainer
 
 from dapla_pseudo.constants import TIMEOUT_DEFAULT
 from dapla_pseudo.constants import PredefinedKeys
@@ -27,6 +28,8 @@ class Repseudonymize:
     """
 
     dataset: File | pl.DataFrame
+    prev_metadata: dict[str, dict[str, list[t.Any]]] | None  # Used in "from_result()"
+    prev_datadoc: MetadataContainer | None  # Used in "from_result()"
 
     @staticmethod
     def from_pandas(
@@ -34,6 +37,8 @@ class Repseudonymize:
     ) -> "Repseudonymize._Repseudonymizer":
         """Initialize a pseudonymization request from a pandas DataFrame."""
         dataset: pl.DataFrame = pl.from_pandas(dataframe)
+        Repseudonymize.prev_metadata = None
+        Repseudonymize.prev_datadoc = None
         if run_as_file:
             file_handle, content_type = get_file_data_from_dataset(dataset)
             Repseudonymize.dataset = File(file_handle, content_type)
@@ -46,6 +51,8 @@ class Repseudonymize:
         dataframe: pl.DataFrame, run_as_file: bool = False
     ) -> "Repseudonymize._Repseudonymizer":
         """Initialize a pseudonymization request from a polars DataFrame."""
+        Repseudonymize.prev_metadata = None
+        Repseudonymize.prev_datadoc = None
         if run_as_file:
             file_handle, content_type = get_file_data_from_dataset(dataframe)
             Repseudonymize.dataset = File(file_handle, content_type)
@@ -76,8 +83,64 @@ class Repseudonymize:
             local_path = "some_file.csv"
             field_selector = Pseudonymize.from_file(local_path))
         """
+        Repseudonymize.prev_metadata = None
+        Repseudonymize.prev_datadoc = None
         file_handle, content_type = get_file_data_from_dataset(dataset)
         Repseudonymize.dataset = File(file_handle, content_type)
+        return Repseudonymize._Repseudonymizer()
+
+    @staticmethod
+    def from_result(
+        result: Result, run_as_file: bool = False
+    ) -> "Repseudonymize._Repseudonymizer":
+        """Initialize a pseudonymization request from a previously computed Result.
+
+        This allows the user to compose results from different pseudonymization operations,
+        (pseudo/depseudo/repseudo), while preserving the metadata as it was a single run.
+        This should not be used for operations of the same pseudo operation,
+        in which case the builder pattern is preserved.
+
+        Args:
+            result: A previously pseudonymized DataFrame
+            run_as_file: Force the dataset to be pseudonymized as a single file.
+
+        Raises:
+            ValueError: If the data structure in the "Result" object is not a DataFrame.
+
+        Returns:
+            _Repseudonymizer: An instance of the _Repseudonymizer class.
+
+        Examples:
+            result = (
+                Pseudonymize
+                    .from_polars(df)
+                    .on_fields("fornavn","etternavn")
+                    .with_default_encryption()
+                    .run()
+                )
+
+            result = (
+                Repseudonymize
+                    .from_result(result)
+                    .on_fields("bolig")
+                    .with_default_encryption()
+                    .run()
+                )
+            result.to_file("gs://ssb-play-obr-data-delt-ledstill-prod/")
+        """
+        Repseudonymize.prev_metadata = result._metadata
+        Repseudonymize.prev_datadoc = result._datadoc
+
+        if run_as_file:
+            file_handle, content_type = get_file_data_from_dataset(result._pseudo_data)
+            Repseudonymize.dataset = File(file_handle, content_type)
+        else:
+            if type(result._pseudo_data) is not pl.DataFrame:
+                raise ValueError(
+                    "Chaining pseudo results can only be done with DataFrames"
+                )
+            Repseudonymize.dataset = result._pseudo_data
+
         return Repseudonymize._Repseudonymizer()
 
     class _Repseudonymizer(_BasePseudonymizer):
@@ -135,13 +198,23 @@ class Repseudonymize:
                 hierarchical=hierarchical,
             )
 
-            return super()._execute_pseudo_operation(
+            result = super()._execute_pseudo_operation(
                 rules=self.source_rules,
                 target_rules=self.target_rules,
                 custom_keyset=source_custom_keyset,
                 target_custom_keyset=target_custom_keyset,
                 timeout=timeout,
             )
+            if (
+                Repseudonymize.prev_datadoc is not None
+                and Repseudonymize.prev_metadata is not None
+            ):  # Add metadata from previous Result
+                result.add_previous_metadata(
+                    Repseudonymize.prev_metadata, Repseudonymize.prev_datadoc
+                )
+                return result
+            else:
+                return result
 
     class _RepseudoFuncSelectorSource(_BaseRuleConstructor):
         def __init__(self, fields: list[str]) -> None:

--- a/tests/v1/integration/test_result.py
+++ b/tests/v1/integration/test_result.py
@@ -5,12 +5,15 @@ from pathlib import Path
 import pandas as pd
 import polars as pl
 import pytest
+from datadoc_model.model import MetadataContainer
+from datadoc_model.model import PseudonymizationMetadata
 from pandas.testing import assert_frame_equal as pd_assert_frame_equal
 from polars.testing import assert_frame_equal as pl_assert_frame_equal
 from tests.v1.integration.utils import integration_test
 
 from dapla_pseudo import Pseudonymize
 from dapla_pseudo.v1.depseudo import Depseudonymize
+from dapla_pseudo.v1.repseudo import Repseudonymize
 
 
 @pytest.mark.usefixtures("setup")
@@ -99,4 +102,46 @@ def test_pseudonymize_add_results(
     assert result_new._metadata == {
         **result._metadata,
         "fnr_pseudo": result_new._metadata["fnr_pseudo"],
+    }
+
+
+@pytest.mark.usefixtures("setup")
+@integration_test()
+def test_pseudonymize_add_results_repseudo(
+    df_personer: pl.DataFrame,
+    df_personer_fnr_daead_encrypted: pl.DataFrame,
+    df_personer_fnr_ff31_encrypted: pl.DataFrame,
+) -> None:
+    # create a new column with a pseudonymized FNR
+    df = df_personer_fnr_daead_encrypted.with_columns(
+        df_personer.get_column("fnr").alias("fnr_2")
+    )
+
+    result = (
+        Repseudonymize.from_polars(df)
+        .on_fields("fnr")
+        .from_default_encryption()
+        .to_papis_compatible_encryption()
+        .run()
+    )
+
+    result_new = (
+        Pseudonymize.from_result(result)
+        .on_fields("fnr_2")
+        .with_default_encryption()
+        .run()
+    )
+
+    new_datadoc_metadata = result._datadoc.pseudonymization.pseudo_variables + [  # type: ignore
+        r
+        for r in result_new._datadoc.pseudonymization.pseudo_variables  # type: ignore
+        if r.short_name == "fnr_2"
+    ]
+
+    assert result_new._datadoc == MetadataContainer(
+        pseudonymization=PseudonymizationMetadata(pseudo_variables=new_datadoc_metadata)
+    )
+    assert result_new._metadata == {
+        **result._metadata,
+        "fnr_2": result_new._metadata["fnr_2"],
     }


### PR DESCRIPTION
In the rare case where you'd want to both pseudonymize _and_ depseudonymize the same dataset, you'd typically chain the process like so:

```python
df = pl.read_parquet("gs://some_bucket/some_folder")

df = (
  Pseudonymize
    .from_polars(df)
    .on_fields("fornavn","etternavn")
    .with_default_encryption()
    .run()
    .to_polars()
)

result = (
  Depseudonymize
    .from_polars(df)
    .on_fields("bolig")
    .with_default_encryption()
    .run()
)
```

However, collapsing the data structure from a `Result` to a `DataFrame` when calling `to_polars()` in the first result causes metadata in the `Result` object to be lost. This is not desirable, especially when pseudonymizing mostly finished data, because the metadata helps track the transition between different data brokers.

The feature in this PR allows you to use the intermediate `Result` object as an input to the next builder, allowing the metadata to be preserved.

Using the previous examples, this looks like:

```python
df = pl.read_parquet("gs://some_bucket/some_folder")

result = (
  Pseudonymize
    .from_polars(df)
    .on_fields("fornavn","etternavn")
    .with_default_encryption()
    .run()
)

result = (
  Depseudonymize
    .from_result(result)
    .on_fields("bolig")
    .with_default_encryption()
    .run()
)
```

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/statisticsnorway/dapla-toolbelt-pseudo/435)
<!-- Reviewable:end -->
