### PR TITLE
Retry all 400 errors

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dapla-toolbelt-pseudo"
-version = "4.0.0"
+version = "4.0.1"
 description = "Pseudonymization extensions for Dapla"
 authors = ["Dapla Developers <dapla-platform-developers@ssb.no>"]
 license = "MIT"

--- a/src/dapla_pseudo/v1/client.py
+++ b/src/dapla_pseudo/v1/client.py
@@ -124,7 +124,15 @@ class PseudoClient:
         async with RetryClient(
             client_session=aio_session,
             retry_options=ExponentialRetry(
-                attempts=5, start_timeout=0.1, max_timeout=30, factor=6
+                attempts=5,
+                start_timeout=0.1,
+                max_timeout=30,
+                factor=6,
+                statuses={
+                    400,
+                }.union(
+                    set(range(500, 600))
+                ),  # Retry all 5xx errors and 400 Bad Request
             ),
         ) as client:
             results = await asyncio.gather(


### PR DESCRIPTION
By default, we only retry 5xx errors. The idea being that we only want to retry when the server is at fault. However, sometimes during scale down, some users experience the following error:

`aiohttp.http_exceptions.TransferEncodingError: 400, message: Not enough data for satisfy transfer length header`

The cost of retries isn't very large, so we now retry all 400 errors to account for this

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/statisticsnorway/dapla-toolbelt-pseudo/445)
<!-- Reviewable:end -->
