### PR TITLE
Disable Keep-Alive for requests towards Pseudo Service

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dapla-toolbelt-pseudo"
-version = "4.1.0"
+version = "4.1.1"
 description = "Pseudonymization extensions for Dapla"
 authors = ["Dapla Developers <dapla-platform-developers@ssb.no>"]
 license = "MIT"

--- a/src/dapla_pseudo/v1/client.py
+++ b/src/dapla_pseudo/v1/client.py
@@ -133,7 +133,8 @@ class PseudoClient:
 
         split_pseudo_requests = self._split_requests(pseudo_requests)
         aio_session = ClientSession(
-            connector=TCPConnector(limit=200), timeout=ClientTimeout(total=60 * 60 * 24)
+            connector=TCPConnector(limit=200, force_close=True),
+            timeout=ClientTimeout(total=60 * 60 * 24),
         )
         async with RetryClient(
             client_session=aio_session,


### PR DESCRIPTION
When a TCP connection is made towards a Kubernetes deployment, this binds to a single pod if Keep-Alive is enabled. In other words, Kubernetes services do not load balance long-lived TCP connections. This means that while we do split the requests, they are all routed to a single pod, making this optimization rather useless.

In order to fix this, we disable Keep-Alive and recreate the connection between every request. This does incur a cost, but it's very marginal compared to achieving true horizontal scaling on the compute in the pseudo service.

See:
https://stackoverflow.com/questions/71155472/aiohttp-clientsession-and-clusterip-not-load-balancing
https://stackoverflow.com/questions/65224181/how-does-kube-proxy-handle-persistent-connections-to-a-service-between-pods

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/statisticsnorway/dapla-toolbelt-pseudo/447)
<!-- Reviewable:end -->
