### PR TITLE
Keep Pandas datatypes when using pyarrow dtypes

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dapla-toolbelt-pseudo"
-version = "4.3.3"
+version = "4.4.0"
 description = "Pseudonymization extensions for Dapla"
 authors = ["Dapla Developers <dapla-platform-developers@ssb.no>"]
 license = "MIT"

--- a/src/dapla_pseudo/v1/baseclasses.py
+++ b/src/dapla_pseudo/v1/baseclasses.py
@@ -10,6 +10,7 @@ import os
 from concurrent.futures import ThreadPoolExecutor
 from datetime import date
 
+import pandas as pd
 import polars as pl
 from dapla_metadata.datasets.core import Datadoc
 
@@ -65,6 +66,7 @@ class _BasePseudonymizer:
         custom_keyset: PseudoKeyset | str | None = None,
         target_custom_keyset: PseudoKeyset | str | None = None,  # used in repseudo
         target_rules: list[PseudoRule] | None = None,  # used in repseudo
+        schema: pd.Series | pl.Schema | None = None,
     ) -> Result:
         if self._dataset is None:
             raise ValueError("No dataset has been provided.")
@@ -92,6 +94,7 @@ class _BasePseudonymizer:
                 for pseudo_rule in (target_rules if target_rules else rules)
             ],
             user_provided_metadata=self._user_provided_metadata,
+            schema=schema,
         )
 
     def _pseudonymize_field(

--- a/src/dapla_pseudo/v1/depseudo.py
+++ b/src/dapla_pseudo/v1/depseudo.py
@@ -26,17 +26,20 @@ class Depseudonymize:
     """
 
     dataset: pl.DataFrame
+    schema: pd.Series | pl.Schema
 
     @staticmethod
     def from_pandas(dataframe: pd.DataFrame) -> "Depseudonymize._Depseudonymizer":
         """Initialize a depseudonymization request from a pandas DataFrame."""
         Depseudonymize.dataset = pl.from_pandas(dataframe)
+        Depseudonymize.schema = dataframe.dtypes
         return Depseudonymize._Depseudonymizer()
 
     @staticmethod
     def from_polars(dataframe: pl.DataFrame) -> "Depseudonymize._Depseudonymizer":
         """Initialize a depseudonymization request from a polars DataFrame."""
         Depseudonymize.dataset = dataframe
+        Depseudonymize.schema = dataframe.schema
         return Depseudonymize._Depseudonymizer()
 
     class _Depseudonymizer(_BasePseudonymizer):
@@ -92,7 +95,7 @@ class Depseudonymize:
             )
 
             result = super()._execute_pseudo_operation(
-                self.rules, timeout, custom_keyset
+                self.rules, timeout, custom_keyset, schema=Depseudonymize.schema
             )
             return result
 

--- a/src/dapla_pseudo/v1/repseudo.py
+++ b/src/dapla_pseudo/v1/repseudo.py
@@ -25,17 +25,20 @@ class Repseudonymize:
     """
 
     dataset: pl.DataFrame
+    schema: pd.Series | pl.Schema
 
     @staticmethod
     def from_pandas(dataframe: pd.DataFrame) -> "Repseudonymize._Repseudonymizer":
         """Initialize a pseudonymization request from a pandas DataFrame."""
         Repseudonymize.dataset = pl.from_pandas(dataframe)
+        Repseudonymize.schema = dataframe.dtypes
         return Repseudonymize._Repseudonymizer()
 
     @staticmethod
     def from_polars(dataframe: pl.DataFrame) -> "Repseudonymize._Repseudonymizer":
         """Initialize a pseudonymization request from a polars DataFrame."""
         Repseudonymize.dataset = dataframe
+        Repseudonymize.schema = dataframe.schema
         return Repseudonymize._Repseudonymizer()
 
     class _Repseudonymizer(_BasePseudonymizer):
@@ -110,6 +113,7 @@ class Repseudonymize:
                 custom_keyset=source_custom_keyset,
                 target_custom_keyset=target_custom_keyset,
                 timeout=timeout,
+                schema=Repseudonymize.schema,
             )
             return result
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -279,6 +279,22 @@ def df_personer_sid_fnr() -> pl.DataFrame:
 
 
 @pytest_cases.fixture()
+def pandas_diverse_datatypes() -> pd.DataFrame:
+    JSON_FILE = "tests/data/diverse_datatypes.json"
+    return pd.read_json(
+        JSON_FILE,
+        dtype={
+            "string_field": "string[pyarrow]",
+            "int_field": "Int64[pyarrow]",
+            "float_field": "Float64[pyarrow]",
+            "date_pseudonymized": "datetime64[s]",
+            "bool_field": "boolean[pyarrow]",
+        },
+        dtype_backend="pyarrow",
+    )
+
+
+@pytest_cases.fixture()
 def single_field_response() -> MagicMock:
     mock_response = MagicMock()
     mock_response.status_code = 200

--- a/tests/data/diverse_datatypes.json
+++ b/tests/data/diverse_datatypes.json
@@ -1,0 +1,16 @@
+[
+    {
+        "fnr": "11854898347",
+        "number": 1,
+        "floater": 1.0,
+        "date_pseudonymized": "2023-10-27T10:30:00",
+        "boolean": true
+    },
+    {
+        "fnr": "11852228347",
+        "number": 10,
+        "floater": -1.0,
+        "date_pseudonymized": "2013-10-27T10:30:00",
+        "boolean": false
+    }
+]

--- a/tests/v1/integration/test_result.py
+++ b/tests/v1/integration/test_result.py
@@ -138,3 +138,20 @@ def test_pseudonymize_input_output_funcs(
         case "polars":
             df_polars = result.to_polars()
             pl_assert_frame_equal(df_polars, df_personer_fnr_daead_encrypted)
+
+
+@pytest.mark.usefixtures("setup")
+@integration_test()
+def test_pseudonymize_with_arrow_dtypes(
+    pandas_diverse_datatypes: pd.DataFrame,
+) -> None:
+    """This test ensures that datatypes are retained when converting internally to and from Pandas."""
+    result = (
+        Pseudonymize.from_pandas(pandas_diverse_datatypes)
+        .on_fields("fnr")
+        .with_default_encryption()
+        .run()
+    )
+
+    df_result = result.to_pandas()
+    assert df_result.dtypes.equals(pandas_diverse_datatypes.dtypes)


### PR DESCRIPTION
When using Pyarrow datatypes with Pandas and passing it to this library, they are swallowed when converting to a Polars DataFrame. This change ensures that the schema will be preserved by setting the datatypes on the resultant Pandas df

Related to: https://engage.cloud.microsoft/main/org/ssb.no/threads/eyJfdHlwZSI6IlRocmVhZCIsImlkIjoiMzU3MTE2NDYxNzc3NzE1MiJ9?trk_copy_link=V2

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/statisticsnorway/dapla-toolbelt-pseudo/459)
<!-- Reviewable:end -->
